### PR TITLE
Generalize TPlan continuation authorization triggers

### DIFF
--- a/docs/methodologies/tplan.md
+++ b/docs/methodologies/tplan.md
@@ -128,7 +128,7 @@ SubAgent 是侦察，不是控制器。
 5. 对关键 claim 记录 evidence，并说明它支撑什么判断。
 6. 遇到路径切换、任务删除、Mission 关闭或高影响继续时，输出 decision packet。
 7. 出现第三次局部处理、负反馈、加层冲动或弱 evidence-delta continuation 时，触发 Anti-Spiral gate。
-8. 准备昂贵同路径继续时，先写 `continuation_authorization`：做继续授权，而不是默认重跑。
+8. 继续同一路径前，先写 `continuation_authorization`：当前路径为什么仍值得继续、下一步会带来什么新证据，不能用次数或惯性替代判断。
 
 实操中，`tplan` 不需要覆盖所有任务。短小、低风险、一次性工作直接执行即可。它适合那些“如果不记录状态就会漂移”的 Mission。
 
@@ -147,7 +147,7 @@ flowchart TD
   F -->|"缺信息 / 权限 / 判断"| I["blocker / stop report<br/>停止并交还最小上下文"]
   F -->|"目标或路径存疑"| J["decision packet<br/>路由到 3L5S / SELA / EDSP / WAE / TVG"]
   F -->|"同一路径反复修补"| K["Anti-Spiral gate<br/>先刹车再判断"]
-  F -->|"昂贵同路径继续"| N["continuation_authorization<br/>继续授权 / 证据形态 / 缺陷分流"]
+  F -->|"同一路径继续"| N["continuation_authorization<br/>继续授权 / 证据形态 / 缺陷分流"]
 
   H --> B
   J --> B
@@ -162,9 +162,9 @@ flowchart TD
 
 ### 继续授权
 
-`continuation_authorization` 是 Linear Continuation Gate 的一部分，用来约束昂贵同路径继续，例如大生成、大重跑或后处理修补后准备再跑一轮。
+`continuation_authorization` 是 Linear Continuation Gate 的一部分。它管的是这种场景：下一步还想沿着同一路径继续，而当前路径的价值、证据增量、缺陷性质或替代路径还需要被说清楚。
 
-次数提醒只负责叫醒，不负责判停。第三次碰同一局部对象、第二次准备大重跑、大生成后出现新缺陷、连续负反馈或弱 evidence delta，只说明需要进入继续授权，不自动停止，也不自动允许重跑。
+次数提醒只负责叫醒，不负责判停。第三次碰同一局部对象、同路径反复继续、继续后出现新缺陷、连续负反馈、高成本/高影响继续或弱 evidence delta，只说明需要进入继续授权，不自动停止，也不自动允许继续。
 
 继续授权只问一个中心问题：继续同一路径凭什么被授权？
 

--- a/skills/tplan/SKILL.md
+++ b/skills/tplan/SKILL.md
@@ -356,13 +356,14 @@ enum values; agentic judgment decides relevance and action.
 #### Continuation Authorization
 
 Mission-facing same-path `continue` decisions must expose `continuation_authorization`.
-This is part of the Linear Continuation Gate, not a new workflow center. It exists for
-expensive reruns, large generation passes, and late-defect repair loops where continuing
-the same path could hide weak evidence delta or local repair spiral pressure.
+This is part of the Linear Continuation Gate, not a new workflow center. It exists when
+continuing the same path could hide weak evidence delta, unclear defect classification,
+local repair spiral pressure, or a high-cost / high-blast-radius continuation choice.
 
-count-based reminders are triggers, not decisions. Third touch, second large rerun,
-post-generation defect, repeated negative feedback, or weak evidence delta only wake up
-the gate. They do not automatically stop, rerun, or change direction.
+count-based reminders are triggers, not decisions. Third touch, repeated same-path
+attempt, a defect found after continuation, repeated negative feedback, high-cost /
+high-blast-radius continuation, or weak evidence delta only wake up the gate. They do
+not automatically stop, continue, or change direction.
 
 `continuation_authorization` records:
 
@@ -371,6 +372,12 @@ the gate. They do not automatically stop, rerun, or change direction.
 - `defect_classification`
 - `expected_evidence_delta`
 - `authorized_action`
+
+Common `trigger_reasons` should use generic same-path continuation reasons such as
+`repeated_same_path_attempt`, `post_continuation_defect`,
+`high_cost_or_high_blast_radius_continuation`, `repeated_negative_feedback`, and
+`weak_or_unclear_evidence_delta`. Pressure-test-specific labels may exist as legacy
+compatibility, but they are not the main concept.
 
 Mechanical checks such as placeholder anchors, sample evidence, empty anchors, template
 residue, or unbound evidence links are shape-only evidence. Scripts validate fields and

--- a/skills/tplan/resources/hooks.md
+++ b/skills/tplan/resources/hooks.md
@@ -101,13 +101,13 @@ route through `anti_spiral_audit` before authorizing same-path continuation.
 ### Continuation Authorization
 
 Mission-facing same-path `continue` decisions require `continuation_authorization`.
-This keeps expensive reruns and large generation passes inside the Linear Continuation
-Gate instead of adding a separate pre-rerun workflow.
+This keeps same-path continuation inside the Linear Continuation Gate instead of adding
+separate pressure-case-specific lint, generation, rerun, or defect-queue workflows.
 
 ```json
 {
   "continuation_authorization": {
-    "trigger_reasons": ["second_large_rerun"],
+    "trigger_reasons": ["repeated_same_path_attempt"],
     "evidence_shape_lint": "pass | fail | not_applicable | unclear",
     "defect_classification": "none | acceptance_blocking | batchable_detail | unclear",
     "expected_evidence_delta": "new_evidence_expected | weak_evidence_expected | no_new_evidence_expected | unclear",
@@ -116,10 +116,10 @@ Gate instead of adding a separate pre-rerun workflow.
 }
 ```
 
-count-based reminders are triggers, not decisions. A third touch, second large rerun,
-post-generation defect, repeated negative feedback, or weak evidence delta only routes
-the decision into this gate. It does not automatically stop the Mission or authorize a
-rerun.
+count-based reminders are triggers, not decisions. A third touch, repeated same-path
+attempt, post-continuation defect, repeated negative feedback, high-cost or
+high-blast-radius continuation, or weak evidence delta only routes the decision into
+this gate. It does not automatically stop the Mission or authorize continuation.
 
 Evidence-shape lint is shape-only evidence. Scripts may flag placeholder anchors,
 sample evidence, empty anchors, template residue, or evidence links not bound to real

--- a/skills/tplan/resources/schema.md
+++ b/skills/tplan/resources/schema.md
@@ -289,13 +289,15 @@ the output must also include `risk_assessment`:
 
 Mission-facing same-path `continue` decisions must include
 `continuation_authorization`. This belongs to the Linear Continuation Gate. It should
-not split into independent pre-rerun lint and defect queue mechanisms.
+not split into independent pressure-case-specific lint, rerun, generation, or defect
+queue mechanisms.
 
 Required `continuation_authorization` fields:
 
-- `trigger_reasons`: list containing `third_touch`, `second_large_rerun`,
-  `post_generation_defect`, `repeated_negative_feedback`,
-  `weak_or_unclear_evidence_delta`, or `manual_authorization`
+- `trigger_reasons`: list containing `third_touch`, `repeated_same_path_attempt`,
+  `post_continuation_defect`, `repeated_negative_feedback`,
+  `high_cost_or_high_blast_radius_continuation`, `weak_or_unclear_evidence_delta`, or
+  `manual_authorization`
 - `evidence_shape_lint`: `pass`, `fail`, `not_applicable`, or `unclear`
 - `defect_classification`: `none`, `acceptance_blocking`, `batchable_detail`, or
   `unclear`
@@ -303,6 +305,10 @@ Required `continuation_authorization` fields:
   `no_new_evidence_expected`, or `unclear`
 - `authorized_action`: `continue_same_path`, `targeted_fix`, `batch_details`,
   `mission_review`, `anti_spiral_audit`, or `stop`
+
+Legacy compatibility: older records may still use `second_large_rerun` or
+`post_generation_defect`, but new records should use the generic same-path continuation
+reasons above.
 
 count-based reminders are triggers, not decisions. Evidence-shape lint is shape-only
 evidence: scripts can report placeholder anchors, sample evidence, empty anchors,

--- a/skills/tplan/scripts/tplan_runtime.py
+++ b/skills/tplan/scripts/tplan_runtime.py
@@ -73,6 +73,11 @@ RISK_ASSESSMENT_FIELDS = {
 
 CONTINUATION_TRIGGER_REASONS = {
     "third_touch",
+    "repeated_same_path_attempt",
+    "post_continuation_defect",
+    "high_cost_or_high_blast_radius_continuation",
+    # Compatibility aliases from the original pressure-test scenario. New records should
+    # prefer the generic same-path continuation reasons above.
     "second_large_rerun",
     "post_generation_defect",
     "repeated_negative_feedback",

--- a/tests/tplan/test_apply_decision.py
+++ b/tests/tplan/test_apply_decision.py
@@ -94,7 +94,7 @@ def valid_risk_assessment():
 
 def valid_continuation_authorization():
     return {
-        "trigger_reasons": ["second_large_rerun"],
+        "trigger_reasons": ["repeated_same_path_attempt"],
         "evidence_shape_lint": "pass",
         "defect_classification": "acceptance_blocking",
         "expected_evidence_delta": "new_evidence_expected",
@@ -399,12 +399,12 @@ class ApplyDecisionTests(unittest.TestCase):
                 json.dumps(
                     {
                         "recommendation": "continue",
-                        "rationale": "Run another expensive same-path generation after late evidence defects.",
+                        "rationale": "Continue the same Mission-facing path after a late evidence defect.",
                         "confidence": 70,
                         "evidence_links": [],
                         "proposed_mutations": [],
                         "requires_human": False,
-                        "mission_alignment": "The rerun claims to advance Mission acceptance evidence.",
+                        "mission_alignment": "The continuation claims to advance Mission acceptance evidence.",
                         "path_assessment": valid_path_assessment(),
                     }
                 ),
@@ -424,12 +424,12 @@ class ApplyDecisionTests(unittest.TestCase):
                 json.dumps(
                     {
                         "recommendation": "continue",
-                        "rationale": "Run a bounded rerun after classifying the defect as acceptance-blocking.",
+                        "rationale": "Continue a bounded same-path action after classifying the defect as acceptance-blocking.",
                         "confidence": 70,
                         "evidence_links": [],
                         "proposed_mutations": [],
                         "requires_human": False,
-                        "mission_alignment": "The rerun can produce decision-constraining acceptance evidence.",
+                        "mission_alignment": "The continuation can produce decision-constraining acceptance evidence.",
                         "path_assessment": valid_path_assessment(),
                         "continuation_authorization": valid_continuation_authorization(),
                     }
@@ -447,12 +447,12 @@ class ApplyDecisionTests(unittest.TestCase):
             decision = Path(tmp) / "decision.json"
             payload = {
                 "recommendation": "continue",
-                "rationale": "Run a bounded rerun after classifying the defect.",
+                "rationale": "Continue a bounded same-path action after classifying the defect.",
                 "confidence": 70,
                 "evidence_links": [],
                 "proposed_mutations": [],
                 "requires_human": False,
-                "mission_alignment": "The rerun can produce decision-constraining acceptance evidence.",
+                "mission_alignment": "The continuation can produce decision-constraining acceptance evidence.",
                 "path_assessment": valid_path_assessment(),
                 "continuation_authorization": valid_continuation_authorization(),
             }

--- a/tests/tplan/test_skill_contract.py
+++ b/tests/tplan/test_skill_contract.py
@@ -265,12 +265,16 @@ class TplanSkillContractTests(unittest.TestCase):
             "batchable_detail",
             "count-based reminders are triggers, not decisions",
             "shape-only evidence",
+            "repeated_same_path_attempt",
+            "post_continuation_defect",
+            "high_cost_or_high_blast_radius_continuation",
         ):
             self.assertIn(phrase, skill_text)
             self.assertIn(phrase, resources)
 
         self.assertIn("继续授权", methodology)
         self.assertIn("次数提醒只负责叫醒，不负责判停", methodology)
+        self.assertIn("继续同一路径前", methodology)
         self.assertIn("Continuation Authorization Pressure", pressure_text)
         self.assertIn("placeholder/sample red-team anchors", pressure_text)
         self.assertIn("continuation_authorization", hook)


### PR DESCRIPTION
## Summary
- reframe continuation_authorization as a generic same-path continuation gate, not a large-rerun/generation-specific mechanism
- add generic trigger reasons while keeping legacy pressure-test aliases compatible
- update TPlan docs, hooks, schema, runtime enum validation, and contract tests

## Verification
- python3 -m unittest tests.tplan.test_skill_contract tests.tplan.test_apply_decision tests.tplan.test_continuation_authorization_ab_simulator