### PR TITLE
feat: add primitive activation model

### DIFF
--- a/docs/methodologies/primitive-activation.md
+++ b/docs/methodologies/primitive-activation.md
@@ -1,0 +1,121 @@
+# Primitive Activation / 原语唤起机制
+
+## 这是什么
+
+Primitive Activation 是认知原语的轻量工程承载方式。
+
+它解决的不是“再造一个方法”，而是让横切原语在少数关键动作前被明确叫醒：
+选方法前、交付 / 冻结前、同路径继续前。
+
+一句话：
+
+> 原语唤起只提醒 agent 该想什么，不替 agent 判断想得对不对。
+
+这比纯文档提醒更硬一点，因为它给原语稳定 `id`、触发事件和行动影响；
+但它不是完整 AOP，不做全生命周期注入，不做通用 hook engine，也不替代
+`SELA`、`MPG`、`3L5S`、`EDSP`、`WAE`、`TVG` 或 `tplan` 的主判断。
+
+## 为什么不是纯文档
+
+`shared-primitives.md` 已经能说明认知原语是什么，但它仍然依赖 agent 记得读、记得用。
+当任务复杂、上下文长、产物看似已经完成时，agent 容易忘记那些横切刹车。
+
+Primitive Activation 的目标是把“记得用”变成一个可执行动作：
+
+```bash
+python3 scripts/primitives/check.py --event before-freeze --method tvg
+```
+
+脚本输出该事件应唤起哪些原语、agent 需要自查哪些点，并明确：
+`script_verdict: shape_only`，`agentic_judgment_required: true`。
+
+## 为什么不是完整 AOP
+
+完整 AOP 会要求定义大量 join point、生命周期阶段和注入规则。Mindthus 当前没有这个诉求。
+
+当前只保留三个轻量事件：
+
+| Event | 什么时候用 | 唤起目标 |
+|---|---|---|
+| `before-route` | 选择 Mindthus 方法前 | 避免简单任务被方法化，避免缺事实时用方法补洞。 |
+| `before-freeze` | 交付、冻结、转交或停止前 | 避免“看起来完成”但目标漂移、证据不足、误用信号未处理。 |
+| `before-continue` | 同路径继续或长任务继续前 | 避免惯性续跑、局部修补螺旋和无证据增量的继续。 |
+
+这三个事件是提醒点，不是强制流程。低风险、明确、机械可验证的小任务可以不跑脚本。
+
+## Primitive Shape
+
+每个 primitive 至少要有稳定形状：
+
+```yaml
+id: gate_probes
+name: Gate Probes / 冻结前定位自省
+short_rule: "交付、冻结、继续、转交或停止前，确认当前位置和目标。"
+trigger:
+  - before-freeze
+  - before-continue
+action_effect:
+  - freeze
+  - return-remediate
+  - block
+  - stop
+  - ask-user-authority
+not_a:
+  - standalone-method
+  - semantic-judge
+  - evidence-substitute
+  - gate-replacement
+owner: shared-primitives
+```
+
+这些字段让 AGENTS、skill、脚本、trace 和后续文档能引用同一个原语，而不是复制一段自然语言。
+
+## 脚本边界
+
+`scripts/primitives/check.py` 只做四件事：
+
+1. 根据 `event` 找到应唤起的 primitives。
+2. 根据 `method` 应用少量条件性唤起，例如 `tplan` 的 continuation authorization。
+3. 返回 required agent checks。
+4. 校验 manifest 形状，防止原语记录坏掉。
+
+它不能：
+
+- 判断是否可以 freeze。
+- 判断 evidence 是否真实充分。
+- 判断方法输出是否正确。
+- 判断审美、业务、策略或用户价值是否成功。
+- 替代用户授权、TVG exit gate 或 tplan continuation authorization。
+
+脚本成功只表示：
+
+> 该事件的原语唤起形状可用；agentic judgment 仍然必需。
+
+## 与 shared-primitives.md 的关系
+
+`shared-primitives.md` 仍然是认知原语的索引和短正本。
+Primitive Activation 负责运行时唤起形态。
+
+当前不急着把每个 primitive 拆成独立文件。更合理的边界是：
+
+- `shared-primitives.md` 保留索引、短定义和关键边界。
+- `primitive-activation.md` 记录结构化形态和脚本边界。
+- 如果某个 primitive 的正文超过约 60 行，或需要独立模板 / schema / casebook，再拆到
+  `docs/methodologies/primitives/<id>.md`。
+
+这样避免 `shared-primitives.md` 变成公共抽屉，也避免为了工程化而过早拆散文档。
+
+## 与现有方法的关系
+
+- `using-mindthus` 可以在路由前使用 `before-route`。
+- `TVG` 可以在 freeze 或继续下一轮前使用 `before-freeze` / `before-continue`。
+- `tplan` 可以在同路径继续前使用 `before-continue`，但 continuation authorization 仍由
+  tplan 自己判断和记录。
+- `WAE` 的边界仍然成立：脚本只控制 shape 和提醒，不控制 truth。
+
+## 导航
+
+- 返回 [shared primitives](shared-primitives.md)
+- 查看 [Using Mindthus skill](../../skills/using-mindthus/SKILL.md)
+- 查看 [tplan](tplan.md)
+- 查看 [TVG](tvg.md)

--- a/docs/methodologies/shared-primitives.md
+++ b/docs/methodologies/shared-primitives.md
@@ -10,6 +10,10 @@ This is not a new method layer. 它不是第七个方法，也不是总入口；
 小型 guardrail 集中成一个 Cognitive Primitive Index / 认知原语索引，供 `AGENTS.md`、
 `using-mindthus` 和各 skill 引用。
 
+当认知原语需要比文档提醒更硬一点时，使用
+[Primitive Activation / 原语唤起机制](primitive-activation.md)：它通过少数轻量事件
+显性唤起相关原语，但仍然只做 shape-only reminder，不替代 agent 判断。
+
 ## 解决什么问题
 
 如果每个 skill 都把同一套刹车、证据上限、表达纪律重新写一遍，项目会有三个问题：
@@ -199,9 +203,11 @@ SELA 负责整体效率与局部优势判断。如果销售、法务、实施、
 - `using-mindthus` 引用本页来避免入口 skill 变厚。
 - `AGENTS.md` 引用本页来保持默认姿态短。
 - 各方法页只保留与本方法相关的触发条件。
+- `Primitive Activation` 用脚本在少数关键事件上唤起原语，但不判断真伪、价值或 exit。
 
 ## 导航
 
 - 返回 [README](../../README.md)
+- 查看 [Primitive Activation](primitive-activation.md)
 - 查看 [Using Mindthus skill](../../skills/using-mindthus/SKILL.md)
 - 查看 [Anti-Spiral 方法页](anti-spiral-self-audit.md)

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -30,7 +30,12 @@ JSONL_ALLOWLIST = {Path("tplan/templates/evidence.jsonl")}
 TEXT_REWRITE_SUFFIXES = {".md"}
 SKILL_NAMES = ("3l5s", "sela", "mpg", "edsp", "wae", "tvg", "tplan", "using-mindthus")
 LICENSE_FILES = ("LICENSE", "COMMERCIAL-LICENSE.md")
-RELEASE_SCRIPTS = ("run-fidelity-judge.py", "log-fidelity-usage.py")
+RELEASE_SCRIPT_PATHS = (
+    Path("run-fidelity-judge.py"),
+    Path("log-fidelity-usage.py"),
+    Path("primitives/check.py"),
+    Path("primitives/manifest.json"),
+)
 
 
 def repo_root() -> Path:
@@ -120,8 +125,8 @@ def copy_license_files(root: Path, target: Path) -> None:
 
 
 def copy_release_scripts(root: Path, target: Path) -> None:
-    for filename in RELEASE_SCRIPTS:
-        copy_file_filtered(root / "scripts" / filename, target / "scripts" / filename)
+    for rel_path in RELEASE_SCRIPT_PATHS:
+        copy_file_filtered(root / "scripts" / rel_path, target / "scripts" / rel_path)
 
 
 def build_claude_code(root: Path, repo: Path, skills_dir: Path, methodologies_dir: Path) -> None:
@@ -210,9 +215,9 @@ def main() -> int:
     for filename in LICENSE_FILES:
         if not (root / filename).is_file():
             raise SystemExit(f"{filename} not found: {root / filename}")
-    for filename in RELEASE_SCRIPTS:
-        if not (root / "scripts" / filename).is_file():
-            raise SystemExit(f"{filename} not found: {root / 'scripts' / filename}")
+    for rel_path in RELEASE_SCRIPT_PATHS:
+        if not (root / "scripts" / rel_path).is_file():
+            raise SystemExit(f"{rel_path} not found: {root / 'scripts' / rel_path}")
 
     output = args.out.resolve()
     ensure_safe_output_dir(output, root)

--- a/scripts/primitives/check.py
+++ b/scripts/primitives/check.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Activate Mindthus shared primitives for a small set of runtime events.
+
+The script validates activation shape and prints reminders. It does not judge semantic
+truth, output quality, evidence sufficiency, Gate success, or whether work may exit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_MANIFEST = SCRIPT_DIR / "manifest.json"
+SCHEMA_VERSION = "mindthus-primitive-activation-v0.1"
+ALLOWED_METHODS = {
+    "using-mindthus",
+    "3l5s",
+    "edsp",
+    "sela",
+    "mpg",
+    "wae",
+    "tvg",
+    "tplan",
+    "unknown",
+}
+
+
+def non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def require_list_of_strings(findings: list[str], data: dict[str, Any], field: str, subject: str) -> None:
+    value = data.get(field)
+    if not isinstance(value, list) or any(not non_empty_string(item) for item in value):
+        findings.append(f"{subject}.{field} must be a list of non-empty strings")
+
+
+def validate_manifest(manifest: Any) -> list[str]:
+    findings: list[str] = []
+    if not isinstance(manifest, dict):
+        return ["manifest root must be an object"]
+
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        findings.append(f"schema_version must be {SCHEMA_VERSION}")
+    if manifest.get("script_boundary") != "shape_only_reminder_not_semantic_judgment":
+        findings.append("script_boundary must be shape_only_reminder_not_semantic_judgment")
+
+    events = manifest.get("events")
+    primitives = manifest.get("primitives")
+    if not isinstance(events, dict) or not events:
+        findings.append("events must be a non-empty object")
+        events = {}
+    if not isinstance(primitives, dict) or not primitives:
+        findings.append("primitives must be a non-empty object")
+        primitives = {}
+
+    for primitive_id, primitive in primitives.items():
+        subject = f"primitives.{primitive_id}"
+        if not non_empty_string(primitive_id):
+            findings.append("primitive id must be a non-empty string")
+        if not isinstance(primitive, dict):
+            findings.append(f"{subject} must be an object")
+            continue
+        for field in ("name", "short_rule", "owner"):
+            if not non_empty_string(primitive.get(field)):
+                findings.append(f"{subject}.{field} must be a non-empty string")
+        for field in ("trigger", "action_effect", "not_a"):
+            require_list_of_strings(findings, primitive, field, subject)
+
+    for event_name, event in events.items():
+        subject = f"events.{event_name}"
+        if not non_empty_string(event_name):
+            findings.append("event id must be a non-empty string")
+        if not isinstance(event, dict):
+            findings.append(f"{subject} must be an object")
+            continue
+        if not non_empty_string(event.get("description")):
+            findings.append(f"{subject}.description must be a non-empty string")
+        for field in ("active_primitives", "required_agent_checks"):
+            require_list_of_strings(findings, event, field, subject)
+        for primitive_id in event.get("active_primitives", []):
+            if primitive_id not in primitives:
+                findings.append(f"{subject}.active_primitives references unknown primitive {primitive_id!r}")
+        conditional = event.get("conditional_primitives", [])
+        if conditional is None:
+            conditional = []
+        if not isinstance(conditional, list):
+            findings.append(f"{subject}.conditional_primitives must be a list when present")
+            continue
+        for index, item in enumerate(conditional):
+            item_subject = f"{subject}.conditional_primitives[{index}]"
+            if not isinstance(item, dict):
+                findings.append(f"{item_subject} must be an object")
+                continue
+            primitive_id = item.get("primitive")
+            method = item.get("method")
+            if primitive_id not in primitives:
+                findings.append(f"{item_subject}.primitive references unknown primitive {primitive_id!r}")
+            if method not in ALLOWED_METHODS:
+                findings.append(f"{item_subject}.method must be one of: {', '.join(sorted(ALLOWED_METHODS))}")
+
+    return findings
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def activation_for(manifest: dict[str, Any], event_name: str, method: str) -> dict[str, Any]:
+    events = manifest["events"]
+    primitives = manifest["primitives"]
+    event = events[event_name]
+    active_ids = list(event["active_primitives"])
+    for item in event.get("conditional_primitives", []):
+        if item.get("method") == method:
+            active_ids.append(item["primitive"])
+
+    active_primitives = [
+        {
+            "id": primitive_id,
+            "name": primitives[primitive_id]["name"],
+            "short_rule": primitives[primitive_id]["short_rule"],
+            "owner": primitives[primitive_id]["owner"],
+            "action_effect": primitives[primitive_id]["action_effect"],
+            "not_a": primitives[primitive_id]["not_a"],
+        }
+        for primitive_id in active_ids
+    ]
+    return {
+        "schema_version": manifest["schema_version"],
+        "event": event_name,
+        "method": method,
+        "active_primitives": active_primitives,
+        "required_agent_checks": event["required_agent_checks"],
+        "script_verdict": "shape_only",
+        "agentic_judgment_required": True,
+        "script_must_not_decide": [
+            "semantic_truth",
+            "evidence_sufficiency",
+            "gate_success",
+            "exit_state",
+            "aesthetic_or_business_success",
+            "user_authority",
+        ],
+    }
+
+
+def print_text_report(report: dict[str, Any]) -> None:
+    print("Primitive Activation Report")
+    print(f"event: {report['event']}")
+    print(f"method: {report['method']}")
+    print()
+    print("active_primitives:")
+    for primitive in report["active_primitives"]:
+        print(f"- {primitive['id']}: {primitive['short_rule']}")
+    print()
+    print("required_agent_checks:")
+    for check in report["required_agent_checks"]:
+        print(f"- {check}")
+    print()
+    print("script_verdict: shape_only")
+    print("agentic_judgment_required: true")
+    print(
+        "Reminder: this script only activates reminders; it does not decide truth, value, Gate success, or exit."
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Activate Mindthus shared primitives for a runtime event.")
+    parser.add_argument("--event", required=True, help="Activation event, e.g. before-freeze.")
+    parser.add_argument("--method", default="unknown", help="Mindthus method context.")
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST), help="Primitive activation manifest path.")
+    parser.add_argument("--json", action="store_true", help="Print JSON instead of text.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manifest_path = Path(args.manifest)
+    try:
+        manifest = load_manifest(manifest_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        print("Primitive Activation Report")
+        print(f"manifest: {manifest_path}")
+        print(f"- BLOCK [manifest-read-failed]: {exc}")
+        print("script_verdict: shape_only_failed")
+        print("agentic_judgment_required: true")
+        return 1
+
+    findings = validate_manifest(manifest)
+    if findings:
+        print("Primitive Activation Report")
+        print(f"manifest: {manifest_path}")
+        for finding in findings:
+            print(f"- BLOCK [invalid-manifest]: {finding}")
+        print("script_verdict: shape_only_failed")
+        print("agentic_judgment_required: true")
+        return 1
+
+    method = args.method.lower()
+    if method not in ALLOWED_METHODS:
+        print("Primitive Activation Report")
+        print(f"- BLOCK [unsupported-method]: method must be one of: {', '.join(sorted(ALLOWED_METHODS))}")
+        print("script_verdict: shape_only_failed")
+        print("agentic_judgment_required: true")
+        return 1
+    if args.event not in manifest["events"]:
+        print("Primitive Activation Report")
+        print(f"- BLOCK [unsupported-event]: event must be one of: {', '.join(sorted(manifest['events']))}")
+        print("script_verdict: shape_only_failed")
+        print("agentic_judgment_required: true")
+        return 1
+
+    report = activation_for(manifest, args.event, method)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print_text_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/primitives/manifest.json
+++ b/scripts/primitives/manifest.json
@@ -1,0 +1,175 @@
+{
+  "schema_version": "mindthus-primitive-activation-v0.1",
+  "script_boundary": "shape_only_reminder_not_semantic_judgment",
+  "events": {
+    "before-route": {
+      "description": "Before selecting a Mindthus method.",
+      "active_primitives": [
+        "minimal_sufficient_lens",
+        "evidence_claim_ceiling"
+      ],
+      "required_agent_checks": [
+        "is_this_clear_low_risk_direct_execution",
+        "are_facts_or_runtime_proof_missing",
+        "what_hard_judgment_point_exists",
+        "which_method_owns_the_next_judgment"
+      ]
+    },
+    "before-freeze": {
+      "description": "Before deliver, freeze, handoff, block, or stop.",
+      "active_primitives": [
+        "gate_probes",
+        "failure_smells",
+        "evidence_claim_ceiling"
+      ],
+      "required_agent_checks": [
+        "current_artifact_or_action_role",
+        "current_state_against_target",
+        "evidence_boundary_and_claim_ceiling",
+        "failure_smell_scan",
+        "next_action_or_downstream_user"
+      ]
+    },
+    "before-continue": {
+      "description": "Before continuing the same path or another value-gain/runtime round.",
+      "active_primitives": [
+        "gate_probes",
+        "anti_spiral",
+        "failure_smells"
+      ],
+      "conditional_primitives": [
+        {
+          "primitive": "continuation_authorization",
+          "method": "tplan"
+        }
+      ],
+      "required_agent_checks": [
+        "why_same_path_is_still_authorized",
+        "next_round_positive_value_or_evidence_delta",
+        "local_repair_spiral_risk",
+        "failure_smell_scan",
+        "stop_or_handoff_condition"
+      ]
+    }
+  },
+  "primitives": {
+    "minimal_sufficient_lens": {
+      "name": "Minimal Sufficient Lens / 最小充分镜头",
+      "short_rule": "能直接判断就不要开方法；一个 skill 足够就不要串联。",
+      "trigger": [
+        "before-route"
+      ],
+      "action_effect": [
+        "direct-execute",
+        "route",
+        "acquire-information",
+        "stop"
+      ],
+      "not_a": [
+        "method-router-replacement",
+        "semantic-judge"
+      ],
+      "owner": "using-mindthus"
+    },
+    "evidence_claim_ceiling": {
+      "name": "Evidence / Claim Ceiling / 证据上限",
+      "short_rule": "结论强度不能超过证据；缺关键事实时降级或阻断。",
+      "trigger": [
+        "before-route",
+        "before-freeze"
+      ],
+      "action_effect": [
+        "downgrade-claim",
+        "gather-evidence",
+        "block",
+        "stop"
+      ],
+      "not_a": [
+        "fact-generator",
+        "evidence-substitute"
+      ],
+      "owner": "WAE"
+    },
+    "gate_probes": {
+      "name": "Gate Probes / 冻结前定位自省",
+      "short_rule": "交付、冻结、继续、转交或停止前，确认当前位置和目标。",
+      "trigger": [
+        "before-freeze",
+        "before-continue"
+      ],
+      "action_effect": [
+        "freeze",
+        "return-remediate",
+        "block",
+        "stop",
+        "ask-user-authority"
+      ],
+      "not_a": [
+        "standalone-method",
+        "semantic-judge",
+        "evidence-substitute",
+        "gate-replacement"
+      ],
+      "owner": "shared-primitives"
+    },
+    "failure_smells": {
+      "name": "Failure Smells / 误用信号",
+      "short_rule": "看见像完成但没推进的信号时先自审；普通信号返修，硬边界阻断。",
+      "trigger": [
+        "before-freeze",
+        "before-continue"
+      ],
+      "action_effect": [
+        "self-audit",
+        "return-remediate",
+        "downgrade-claim",
+        "reroute",
+        "block",
+        "stop"
+      ],
+      "not_a": [
+        "mechanical-block-list",
+        "semantic-judge"
+      ],
+      "owner": "shared-primitives"
+    },
+    "anti_spiral": {
+      "name": "Anti-Spiral / 反螺旋",
+      "short_rule": "同一局部对象第三次、负反馈或加层冲动出现时，先停下回看上游。",
+      "trigger": [
+        "before-continue"
+      ],
+      "action_effect": [
+        "stop",
+        "return-upstream",
+        "subtract",
+        "reroute",
+        "ask-user-authority"
+      ],
+      "not_a": [
+        "standalone-method",
+        "automatic-stop-rule"
+      ],
+      "owner": "anti-spiral-self-audit"
+    },
+    "continuation_authorization": {
+      "name": "Continuation Authorization / 继续授权",
+      "short_rule": "同路径继续前说明继续凭什么被授权，以及下一步会带来什么新证据。",
+      "trigger": [
+        "before-continue"
+      ],
+      "action_effect": [
+        "authorize-continue",
+        "mission-review",
+        "stop",
+        "ask-user-authority"
+      ],
+      "not_a": [
+        "generic-primitive",
+        "evidence-substitute",
+        "automatic-continue-rule"
+      ],
+      "owner": "tplan"
+    }
+  }
+}

--- a/tests/test_mindthus_router_contract.py
+++ b/tests/test_mindthus_router_contract.py
@@ -390,6 +390,8 @@ class MindthusRouterContractTests(unittest.TestCase):
             "No Abstract Jargon Wall",
             "Approximate Quantified Mapping",
             "非精准量化显影",
+            "Gate Probes",
+            "Failure Smells",
         ):
             self.assertIn(phrase, primitives)
 
@@ -435,11 +437,19 @@ class MindthusRouterContractTests(unittest.TestCase):
                 ),
                 "No Abstract Jargon Wall": (
                     "`AGENTS.md`",
-                    "先用例子、类比或直接后果讲清楚，再使用 Mindthus 术语。",
+                    "先做表达定位：我代表什么立场、文字直接服务谁、要把对方带到哪里；先用例子、类比或直接后果讲清楚，再使用 Mindthus 术语。",
                 ),
                 "Approximate Quantified Mapping / 非精准量化显影": (
                     "`AGENTS.md` / `using-mindthus`",
                     "数字是假设，关系才是重点；用假设数字显影变量、方向、主导项、敏感项和口径差，不用数字证明或计算结论。",
+                ),
+                "Gate Probes / 冻结前定位自省": (
+                    "`AGENTS.md` / `shared-primitives`",
+                    "交付、冻结、继续、转交或停止前，确认当前产物是什么、现在处于什么状态、接下来服务谁的什么行动。",
+                ),
+                "Failure Smells / 误用信号": (
+                    "`shared-primitives` / 各方法",
+                    "看见“像完成但没推进”的信号时先自审；普通信号触发返修或降级，硬边界触发 block / stop。",
                 ),
             },
         )

--- a/tests/test_primitive_activation.py
+++ b/tests/test_primitive_activation.py
@@ -1,0 +1,89 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "primitives" / "check.py"
+MANIFEST = ROOT / "scripts" / "primitives" / "manifest.json"
+
+
+def run_check(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+class PrimitiveActivationTests(unittest.TestCase):
+    def test_before_freeze_activates_gate_smells_and_claim_ceiling(self) -> None:
+        result = run_check("--event", "before-freeze", "--method", "tvg", "--json")
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        report = json.loads(result.stdout)
+
+        self.assertEqual(report["script_verdict"], "shape_only")
+        self.assertIs(report["agentic_judgment_required"], True)
+        self.assertEqual(
+            [item["id"] for item in report["active_primitives"]],
+            [
+                "gate_probes",
+                "failure_smells",
+                "evidence_claim_ceiling",
+            ],
+        )
+        self.assertIn("gate_success", report["script_must_not_decide"])
+
+    def test_before_continue_adds_tplan_continuation_authorization_only_for_tplan(self) -> None:
+        tplan_result = run_check("--event", "before-continue", "--method", "tplan", "--json")
+        self.assertEqual(tplan_result.returncode, 0, tplan_result.stderr + tplan_result.stdout)
+        tplan_report = json.loads(tplan_result.stdout)
+        self.assertIn(
+            "continuation_authorization",
+            [item["id"] for item in tplan_report["active_primitives"]],
+        )
+
+        tvg_result = run_check("--event", "before-continue", "--method", "tvg", "--json")
+        self.assertEqual(tvg_result.returncode, 0, tvg_result.stderr + tvg_result.stdout)
+        tvg_report = json.loads(tvg_result.stdout)
+        self.assertNotIn(
+            "continuation_authorization",
+            [item["id"] for item in tvg_report["active_primitives"]],
+        )
+
+    def test_manifest_has_minimal_shape_for_every_primitive(self) -> None:
+        manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        self.assertEqual(manifest["script_boundary"], "shape_only_reminder_not_semantic_judgment")
+
+        for primitive_id, primitive in manifest["primitives"].items():
+            self.assertTrue(primitive_id)
+            self.assertTrue(primitive["name"])
+            self.assertTrue(primitive["short_rule"])
+            self.assertTrue(primitive["trigger"])
+            self.assertTrue(primitive["action_effect"])
+            self.assertTrue(primitive["not_a"])
+            self.assertTrue(primitive["owner"])
+
+    def test_release_pack_includes_primitive_activation_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "release"
+            result = subprocess.run(
+                [sys.executable, str(ROOT / "scripts" / "build-release-pack.py"), "--out", str(out)],
+                cwd=ROOT,
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            for platform in ("claude-code/claude-plugin", "codex", "opencode"):
+                self.assertTrue((out / platform / "scripts" / "primitives" / "check.py").is_file())
+                self.assertTrue((out / platform / "scripts" / "primitives" / "manifest.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `Primitive Activation / 原语唤起机制` docs to define the lightweight AOP-style middle ground: structured primitives plus only three activation events.
- Add `scripts/primitives/check.py` and `scripts/primitives/manifest.json` so agents can explicitly activate shared primitives before route/freeze/continue events.
- Keep the script boundary strict: shape-only reminder, no semantic truth, evidence sufficiency, Gate success, exit, business, aesthetic, or user-authority judgment.
- Include the primitive activation assets in release packs.
- Add unittest coverage for activation output, tplan-only continuation authorization, manifest shape, and release-pack inclusion.

Closes #44.

## Verification

- `python3 scripts/primitives/check.py --event before-freeze --method tvg`
- `python3 scripts/primitives/check.py --event before-continue --method tplan --json`
- `python3 -m unittest tests.test_primitive_activation -v`
- `python3 -m unittest tests.test_packaging_docs -v`
- `python3 -m unittest tests.test_method_layering_contract -v`
- `python3 -m py_compile scripts/primitives/check.py scripts/build-release-pack.py tests/test_primitive_activation.py`
- `python3 -m unittest discover -s tests -v` （190 tests）
- `git diff --check`
