### PR TITLE
release: v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,33 @@
 
 ## Unreleased
 
+暂无。
+
+## v1.1.1
+
+发布日期：2026-06-17
+
+[完整发布日志](docs/releases/v1.1.1.md)
+
+说明：本版把最近两波 agent runtime 改动收成一个小版本：TPlan 增加 Mission 级共享记忆文件和启动前身份预检，Mindthus router 增加 SELA / MPG / EDSP 的低频方法唤醒 canary。它们都服务同一个目标：让 agent 在长任务和方法选择时少丢上下文、少被高频默认路径吸走。
+
 ### 新增
 
+- TPlan Mission Shared Context Memory：在项目级 `.tplan/shared_contexts/` 下保存 Mission 共享记忆 Markdown，路径形如 `.tplan/shared_contexts/tplan_mission_shared_context-<mission_id>.md`。`preflight_mission.py` 在启动前区分 `continue_existing`、`create_new` 和 `needs_agentic_selection`，`init_lite.py` / `init_mission.py` 可以加载或创建对应 context。
 - Router wake-up canary：`using-mindthus` 增加 `SELA`、`MPG`、`EDSP` 的轻量唤醒探针，并在 `AGENTS.md` 中明确 `3L5S` 不是默认判断归宿，避免结构歧义、战略系统/局部取舍和主线承载问题被高频方法吸收。
 - 新增 router wake-up A/B 分析脚本、fixture、实验设计和弱提示校准记录，用于后续比较 baseline / treatment 的 positive wake-up recall、skip precision、execution impact、adjacent absorption 和 overuse 风险。
 
 ### 边界
 
+- `source_contexts` / `derived_from` 只是新 Mission 的背景记忆和来源关系，不继承旧 Mission 的 acceptance authority；脚本只做路径、字段和 preflight shape 检查，不判断两个 Mission 是否语义相同。
 - 这次 canary 不声明已经证明低频方法唤醒率显著提升。已完成的 known set 和 weak-cue v1 pilot 都触发 baseline-ceiling，说明当前样本没有足够区分度；后续需要真实 replay 或更间接的多轮边界样本继续认证。
+
+### 验证
+
+- `python3 -m unittest discover -s tests -v`
+- `python3 -m unittest tests.tplan.test_mission_shared_context tests.tplan.test_mission_shared_context_agent_simulator tests.tplan.test_skill_contract -v`
+- `python3 -m py_compile skills/tplan/scripts/*.py scripts/router-wakeup-ab.py tests/tplan/mission_shared_context_agent_simulator.py tests/test_router_wakeup_ab_runner.py`
+- `python3 scripts/build-release-pack.py --out /tmp/mindthus-v1.1.1-check --force`
 
 ## v1.1.0
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ python3 scripts/log-fidelity-usage.py --help
 
 ## 版本与许可
 
-当前仓库版本：`v1.1.0`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
+当前仓库版本：`v1.1.1`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
 
 Mindthus uses AGPLv3 + commercial dual licensing.
 

--- a/docs/releases/v1.1.1.md
+++ b/docs/releases/v1.1.1.md
@@ -1,0 +1,69 @@
+# Mindthus v1.1.1 发布日志
+
+发布日期：2026-06-17
+
+## 版本定位
+
+`v1.1.1` 是一次小版本发布，收束最近两波 agent runtime 改动：
+
+- TPlan Mission Shared Context Memory：让长任务在启动、恢复和跨运行时保留 Mission 级共享记忆。
+- Router wake-up canary：让 `using-mindthus` 更容易注意到 SELA、MPG、EDSP 这些低频但关键的方法入口。
+
+这版不改变 Mindthus 的基本定位。它仍然是给 agent 用的判断和执行基础设施，不是让用户填写更多流程。
+
+## 新增
+
+### TPlan Mission Shared Context Memory
+
+TPlan 现在可以在项目级目录保存 Mission 共享记忆：
+
+```text
+.tplan/shared_contexts/tplan_mission_shared_context-<mission_id>.md
+```
+
+这个 Markdown 文件承载 Mission snapshot、当前状态、共享风险、关键发现、恢复说明和 `source_contexts`。`mission.json.shared_context` 仍然保留机器可读运行时索引，用于 active risk signals、survey、decision packet 和校验。
+
+新增 `preflight_mission.py`，用于在启动前判断：
+
+- `continue_existing`：有匹配的 Mission shared context，可以继续；
+- `create_new`：没有对应 context，可以创建新 Mission；
+- `needs_agentic_selection`：存在多个候选 context，需要 agent 或用户判断；
+- conflict：mission_id 对上了，但 objective 或 acceptance evidence 不一致，不能静默继续。
+
+`init_lite.py` 和 `init_mission.py` 可以在提供 `mission_id` 时加载对应 context，也会在新 Mission 缺少文件时创建新的 shared context Markdown。
+
+### Router wake-up canary
+
+`using-mindthus` 增加 SELA、MPG、EDSP 的轻量唤醒探针：
+
+- `SELA`：真实局部优势可能被系统级成本、规模、反馈或分发效率改写主线；
+- `MPG`：主线已经足够明确，但 carrier、vehicle、exposure、timing 或 authority 可能先失败；
+- `EDSP`：A/B 都像对，可能是命题、维度、边界或评价轴本身有问题。
+
+同时，`AGENTS.md` 明确 `3L5S` 是默认问题内核，不是默认判断归宿。结构歧义、战略系统/局部取舍和主线承载问题，应该直接唤醒 EDSP、SELA 或 MPG，而不是先绕回高频方法。
+
+本版也新增 `scripts/router-wakeup-ab.py` 和配套实验设计，用于后续记录 positive wake-up recall、skip precision、execution impact、adjacent absorption、overuse 和 `baseline-ceiling`。
+
+## 边界
+
+TPlan shared context memory 不替 agent 判断 Mission 是否语义连续。`source_contexts` / `derived_from` 只是背景记忆和来源关系，不继承旧 Mission 的 acceptance authority。脚本只检查路径、字段、shape 和显式冲突；是否继续、另开 Mission 或引用旧 context，仍由 agent 或用户判断。
+
+Router wake-up canary 不声明已经证明低频方法唤醒率显著提升。已完成的 known set 和 weak-cue v1 pilot 都触发 `baseline-ceiling`，说明当前样本没有足够区分度。它们可以证明 runner、记录和 claim ceiling 的形状，但不能证明行为 lift。后续需要真实 replay 或更间接的多轮边界样本继续认证。
+
+## 验证
+
+本次发布准备通过：
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 -m unittest tests.tplan.test_mission_shared_context tests.tplan.test_mission_shared_context_agent_simulator tests.tplan.test_skill_contract -v
+python3 -m py_compile skills/tplan/scripts/*.py scripts/router-wakeup-ab.py tests/tplan/mission_shared_context_agent_simulator.py tests/test_router_wakeup_ab_runner.py
+python3 scripts/build-release-pack.py --out /tmp/mindthus-v1.1.1-check --force
+```
+
+发布包 smoke 还应确认：
+
+- 三平台 release pack 的 plugin metadata 版本为 `1.1.1`；
+- `tplan` skill 中包含 `Mission Shared Context Memory` 和 `preflight_mission.py`；
+- `using-mindthus` skill 中包含 `Wake-Up Probes / 唤醒探针`；
+- release pack 仍过滤 tests、logs、`.tplan/`、`.tvg/`、运行产物和临时文件。

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -9,7 +9,7 @@ import shutil
 from pathlib import Path
 
 
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 EXCLUDED_DIRS = {
     "__pycache__",
     ".pytest_cache",

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -54,7 +54,7 @@ class PackagingDocsTests(unittest.TestCase):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         self.assertIn("mindthus:tplan", readme)
         self.assertIn("mindthus:*", readme)
-        self.assertIn("当前仓库版本：`v1.1.0`", readme)
+        self.assertIn("当前仓库版本：`v1.1.1`", readme)
         self.assertIn("scripts/log-fidelity-usage.py", readme)
         self.assertIn("data/fidelity-usage-log.jsonl", readme)
         self.assertIn("AGPLv3 + commercial dual licensing", readme)
@@ -208,6 +208,7 @@ class PackagingDocsTests(unittest.TestCase):
     def test_changelog_release_sections_are_chinese_and_not_duplicated(self):
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
         lines = changelog.splitlines()
+        self.assertEqual(lines.count("## v1.1.1"), 1)
         self.assertEqual(lines.count("## v1.1.0"), 1)
         self.assertEqual(lines.count("## v1.0.1"), 1)
         self.assertEqual(lines.count("## v1.0"), 1)
@@ -541,7 +542,7 @@ class PackagingDocsTests(unittest.TestCase):
             source = marketplace["plugins"][0]["source"]
             self.assertEqual(source, "./claude-plugin")
             self.assertNotIn("..", source)
-            self.assertEqual(plugin["version"], "1.1.0")
+            self.assertEqual(plugin["version"], "1.1.1")
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "tplan" / "SKILL.md").exists())
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "mpg" / "SKILL.md").exists())
             for path in sorted((out / "claude-code" / "claude-plugin" / "skills").glob("*/SKILL.md")):

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -6,26 +6,60 @@ REPO = Path(__file__).resolve().parents[1]
 
 
 class ReleaseBoundaryContractTests(unittest.TestCase):
-    def test_current_release_surface_is_v1_1_0(self):
+    def test_current_release_surface_is_v1_1_1(self):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
         builder = (REPO / "scripts" / "build-release-pack.py").read_text(encoding="utf-8")
 
-        self.assertIn("当前仓库版本：`v1.1.0`", readme)
-        self.assertIn("## v1.1.0", changelog)
-        self.assertIn("[完整发布日志](docs/releases/v1.1.0.md)", changelog)
-        self.assertIn("TVG Value Profile", changelog)
-        self.assertIn("TVG 示例 profile", changelog)
-        self.assertIn("TPlan Shared Risk Context", changelog)
-        self.assertIn("TPlan continuation authorization", changelog)
-        self.assertIn("Codex 安装路径", changelog)
-        self.assertIn("不会替 agent 判断 profile 是否审美成功", changelog)
-        self.assertIn("是否具备稳定视觉泛化能力", changelog)
-        self.assertIn('VERSION = "1.1.0"', builder)
+        self.assertIn("当前仓库版本：`v1.1.1`", readme)
+        self.assertIn("## v1.1.1", changelog)
+        self.assertIn("[完整发布日志](docs/releases/v1.1.1.md)", changelog)
+        self.assertIn("TPlan Mission Shared Context Memory", changelog)
+        self.assertIn("Router wake-up canary", changelog)
+        self.assertIn("preflight_mission.py", changelog)
+        self.assertIn("不声明已经证明低频方法唤醒率显著提升", changelog)
+        self.assertIn("不继承旧 Mission 的 acceptance authority", changelog)
+        self.assertIn('VERSION = "1.1.1"', builder)
+
+        release_log = (REPO / "docs" / "releases" / "v1.1.1.md").read_text(
+            encoding="utf-8"
+        )
+        for phrase in (
+            "# Mindthus v1.1.1 发布日志",
+            "发布日期：2026-06-17",
+            "TPlan Mission Shared Context Memory",
+            ".tplan/shared_contexts/tplan_mission_shared_context-<mission_id>.md",
+            "preflight_mission.py",
+            "source_contexts",
+            "Router wake-up canary",
+            "baseline-ceiling",
+            "不声明已经证明低频方法唤醒率显著提升",
+            "不继承旧 Mission 的 acceptance authority",
+            "python3 -m unittest discover -s tests -v",
+            "python3 scripts/build-release-pack.py",
+        ):
+            self.assertIn(phrase, release_log)
+
+        self.assertNotIn("Release date:", release_log)
+
+    def test_v1_1_0_release_surface_is_preserved(self):
+        changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
 
         release_log = (REPO / "docs" / "releases" / "v1.1.0.md").read_text(
             encoding="utf-8"
         )
+        self.assertIn("## v1.1.0", changelog)
+        self.assertIn("[完整发布日志](docs/releases/v1.1.0.md)", changelog)
+        for phrase in (
+            "TVG Value Profile",
+            "TVG 示例 profile",
+            "TPlan Shared Risk Context",
+            "TPlan continuation authorization",
+            "Codex 安装路径",
+            "不会替 agent 判断 profile 是否审美成功",
+            "是否具备稳定视觉泛化能力",
+        ):
+            self.assertIn(phrase, changelog)
         for phrase in (
             "两个影视提示词 / 分镜方向的示范 profile",
             "邵氏清水湾棚拍时代武侠 / 神怪",

--- a/tests/test_v0_9_acceptance.py
+++ b/tests/test_v0_9_acceptance.py
@@ -30,7 +30,7 @@ class V09AcceptanceTests(unittest.TestCase):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
 
-        for phrase in ("v1.1.0", "GitHub Releases"):
+        for phrase in ("v1.1.1", "GitHub Releases"):
             self.assertIn(phrase, readme)
 
         for phrase in (

--- a/tests/test_v1_0_1_usage_log.py
+++ b/tests/test_v1_0_1_usage_log.py
@@ -145,7 +145,7 @@ class V101UsageLogTests(unittest.TestCase):
         )
 
         for phrase in (
-            "当前仓库版本：`v1.1.0`",
+            "当前仓库版本：`v1.1.1`",
             "scripts/log-fidelity-usage.py",
             "data/fidelity-usage-log.jsonl",
             "可选：记录使用效果",
@@ -174,7 +174,7 @@ class V101UsageLogTests(unittest.TestCase):
                     / "plugin.json"
                 ).read_text(encoding="utf-8")
             )
-            self.assertEqual(plugin["version"], "1.1.0")
+            self.assertEqual(plugin["version"], "1.1.1")
             for platform_root in (
                 root / "claude-code" / "claude-plugin",
                 root / "codex",

--- a/tests/test_v1_0_readiness.py
+++ b/tests/test_v1_0_readiness.py
@@ -106,7 +106,7 @@ class V10ReadinessTests(unittest.TestCase):
 
         self.assertIn("AGPLv3 + commercial dual licensing", readme)
         self.assertIn("closed-source commercial use requires a separate commercial license", readme)
-        self.assertIn("当前仓库版本：`v1.1.0`", readme)
+        self.assertIn("当前仓库版本：`v1.1.1`", readme)
         self.assertNotIn("Pre-1.0", readme)
 
     def test_release_pack_carries_license_judge_script_and_rubric(self):


### PR DESCRIPTION
## Summary
- Publishes v1.1.1 for the recent TPlan Mission Shared Context Memory and router wake-up canary changes.
- Updates README, CHANGELOG, release notes, release-pack metadata, and release boundary tests.
- Preserves the canary claim ceiling: router wake-up lift is not statistically certified yet.

## Test Plan
- python3 -m unittest discover -s tests -v
- python3 -m unittest tests.tplan.test_mission_shared_context tests.tplan.test_mission_shared_context_agent_simulator tests.tplan.test_skill_contract -v
- python3 -m py_compile skills/tplan/scripts/*.py scripts/router-wakeup-ab.py tests/tplan/mission_shared_context_agent_simulator.py tests/test_router_wakeup_ab_runner.py
- python3 scripts/router-wakeup-ab.py --scores tests/router_wakeup_ab_scores.fixture.jsonl --experiment known --json
- python3 scripts/build-release-pack.py --out /tmp/mindthus-v1.1.1-check --force