### PR TITLE
Add Codex plugin release packaging

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,8 +1,8 @@
 # Installing Mindthus for Codex
 
-Enable Mindthus skills in Codex through native skill discovery.
+Enable Mindthus skills in Codex through plugin mode or native skill discovery.
 
-This is the bundle-style installation path for the `mindthus:*` namespace.
+The bundle-style skills-pack path provides the `mindthus:*` namespace.
 Codex's system `skill-installer` is useful for individual skills, but it installs them into `~/.codex/skills` rather than as a grouped namespace bundle.
 
 ## Prerequisites
@@ -10,7 +10,22 @@ Codex's system `skill-installer` is useful for individual skills, but it install
 - Git
 - Access to the private `rv198-star/Mindthus` repository
 
-## Installation
+## Choose A Mode
+
+- **Codex plugin mode**：把 Mindthus 作为一个 Codex App plugin 管理。适合想要统一启用、禁用和识别 Mindthus 的用户。
+- **skills-pack mode**：创建 `${CODEX_HOME:-~/.codex}/skills/mindthus -> <repo>/skills`。适合 portable checkout、开发调试或不使用插件管理的环境。
+
+同一个 Codex profile 中不要同时启用 Codex plugin mode 和 skills-pack mode，除非你明确想测试重复 discovery。迁移到 plugin mode 前，先移除旧的 `~/.codex/skills/mindthus` symlink。
+
+轻量路由纪律：
+
+> 当问题涉及战略判断、结构歧义、路径波动、控制边界、产物价值厚度时，优先使用 `using-mindthus` 选择最小充分方法；清楚低风险任务直接执行。
+
+## Codex Plugin Mode
+
+Generated release packs include `codex-plugin/mindthus/` with `.codex-plugin/plugin.json` and the same packaged `skills/` tree. Use this mode when Codex App should present Mindthus as one plugin product.
+
+## Skills-Pack Mode Installation
 
 1. Clone the repository:
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Mindthus 适合放进真实 agent 工作流，尤其是这些场景：
 
 ## 安装
 
+Mindthus 有两种安装形态：
+
+- **plugin mode**：适合 Codex App 和 Claude Code，把 Mindthus 当作一个插件产品启用；Codex 使用 `using-mindthus`，Claude Code plugin mode 使用 `/mindthus:using-mindthus`。
+- **skills-pack mode**：适合 portable checkout、开发调试和 OpenCode。OpenCode 继续使用 skills-pack；v1.2 不提供 OpenCode plugin mode，因为当前 OpenCode plugin API 尚未验证能原生贡献 `SKILL.md` skills。
+
+同一个 client profile 里不要同时启用 plugin mode 和 skills-pack mode，除非你明确想测试重复 discovery。
+
 ### Codex
 
 详细说明见 [.codex/INSTALL.md](.codex/INSTALL.md)。
@@ -99,6 +106,8 @@ scripts/install-skills.sh codex --force
 
 ### Claude Code
 
+Claude Code plugin mode 会给 skills 增加插件命名空间，例如 `/mindthus:using-mindthus`。下面的 personal skills 安装方式不会增加 `mindthus:` prefix，通常暴露为 `/<skill>` 或由 Claude 自动调用。
+
 Claude Code personal skills 默认位于 `~/.claude/skills/`。
 
 ```bash
@@ -108,6 +117,10 @@ scripts/install-skills.sh claude --force
 ```
 
 重启 Claude Code 后即可使用同一套本地 skills。Claude Code 的本地安装路径不会自动增加 `mindthus:` namespace prefix。
+
+### OpenCode
+
+OpenCode 继续使用 skills-pack mode：生成包中的 `.opencode/skills/mindthus/<skill>/SKILL.md` 是当前支持路径。OpenCode 虽然有 plugin system，但 v1.2 不用 hook、command 或 custom tool 模拟 native skills。
 
 ## 验证
 

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -36,6 +36,10 @@ RELEASE_SCRIPT_PATHS = (
     Path("primitives/check.py"),
     Path("primitives/manifest.json"),
 )
+LIGHT_ROUTER_PROMPT = (
+    "当问题涉及战略判断、结构歧义、路径波动、控制边界、产物价值厚度时，"
+    "优先使用 using-mindthus 选择最小充分方法；清楚低风险任务直接执行。"
+)
 
 
 def repo_root() -> Path:
@@ -90,8 +94,10 @@ def copy_tree_filtered(
     target: Path,
     replacements: dict[str, str] | None = None,
     binary_asset_allowlist: set[Path] | None = None,
+    jsonl_allowlist: set[Path] | None = None,
 ) -> None:
     binary_asset_allowlist = binary_asset_allowlist or set()
+    jsonl_allowlist = JSONL_ALLOWLIST if jsonl_allowlist is None else jsonl_allowlist
     for item in sorted(source.rglob("*")):
         rel = item.relative_to(source)
         if any(part in EXCLUDED_DIRS for part in rel.parts):
@@ -105,7 +111,7 @@ def copy_tree_filtered(
             continue
         if item.suffix in EXCLUDED_SUFFIXES and rel not in binary_asset_allowlist:
             continue
-        if item.suffix == ".jsonl" and rel not in JSONL_ALLOWLIST:
+        if item.suffix == ".jsonl" and rel not in jsonl_allowlist:
             continue
         copy_file_filtered(item, dest, replacements)
 
@@ -181,6 +187,59 @@ def build_codex(root: Path, repo: Path, skills_dir: Path, agents_file: Path, met
     copy_release_scripts(repo, platform_root)
 
 
+def build_codex_plugin(root: Path, repo: Path, skills_dir: Path, methodologies_dir: Path) -> None:
+    plugin_root = root / "codex-plugin" / "mindthus"
+    write_json(
+        plugin_root / ".codex-plugin" / "plugin.json",
+        {
+            "name": "mindthus",
+            "version": VERSION,
+            "description": "Judgment framework skills that help agents choose the right method before acting.",
+            "author": {"name": "Mindthus"},
+            "homepage": "https://github.com/rv198-star/Mindthus",
+            "repository": "https://github.com/rv198-star/Mindthus",
+            "license": "AGPL-3.0-or-commercial",
+            "keywords": [
+                "judgment",
+                "agent-workflow",
+                "skills",
+                "decision-making",
+                "tplan",
+                "sela",
+                "mpg",
+            ],
+            "skills": "./skills/",
+            "interface": {
+                "displayName": "Mindthus",
+                "shortDescription": "Choose the right judgment lens before acting",
+                "longDescription": (
+                    "Mindthus is a judgment framework for AI agents. It helps Codex route "
+                    "unclear, strategic, path-dependent, evidence-bound, or artifact-quality "
+                    "problems to the smallest sufficient method instead of adding process everywhere."
+                ),
+                "developerName": "Mindthus",
+                "category": "Engineering",
+                "capabilities": ["Interactive", "Read"],
+                "websiteURL": "https://github.com/rv198-star/Mindthus",
+                "privacyPolicyURL": "https://github.com/rv198-star/Mindthus",
+                "termsOfServiceURL": "https://github.com/rv198-star/Mindthus",
+                "defaultPrompt": [LIGHT_ROUTER_PROMPT],
+            },
+        },
+    )
+    for skill_name in SKILL_NAMES:
+        jsonl_allowlist = {Path("templates/evidence.jsonl")} if skill_name == "tplan" else set()
+        copy_tree_filtered(skills_dir / skill_name, plugin_root / "skills" / skill_name, jsonl_allowlist=jsonl_allowlist)
+    copy_tree_filtered(skills_dir / "_runtime", plugin_root / "_runtime")
+    copy_tree_filtered(
+        methodologies_dir,
+        plugin_root / "docs" / "methodologies",
+        binary_asset_allowlist=METHODOLOGY_BINARY_ASSET_ALLOWLIST,
+    )
+    copy_license_files(repo, plugin_root)
+    copy_release_scripts(repo, plugin_root)
+
+
 def build_opencode(root: Path, repo: Path, skills_dir: Path, agents_file: Path, methodologies_dir: Path) -> None:
     platform_root = root / "opencode"
     replacements = skill_path_replacements(".opencode/skills/mindthus")
@@ -224,6 +283,7 @@ def main() -> int:
     ensure_output_dir(output, args.force)
     build_claude_code(output, root, skills_dir, methodologies_dir)
     build_codex(output, root, skills_dir, agents_file, methodologies_dir)
+    build_codex_plugin(output, root, skills_dir, methodologies_dir)
     build_opencode(output, root, skills_dir, agents_file, methodologies_dir)
     print(f"built Mindthus release pack at {output}")
     return 0

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -404,6 +404,7 @@ class PackagingDocsTests(unittest.TestCase):
         jsonl_allowlist = {
             Path("claude-code/claude-plugin/skills/tplan/templates/evidence.jsonl"),
             Path("codex/skills/mindthus/tplan/templates/evidence.jsonl"),
+            Path("codex-plugin/mindthus/skills/tplan/templates/evidence.jsonl"),
             Path("opencode/.opencode/skills/mindthus/tplan/templates/evidence.jsonl"),
         }
         binary_asset_allowlist = {
@@ -411,6 +412,8 @@ class PackagingDocsTests(unittest.TestCase):
             Path("claude-code/claude-plugin/docs/methodologies/assets/tvg-architecture.png"),
             Path("codex/docs/methodologies/assets/tplan-okr-runtime.png"),
             Path("codex/docs/methodologies/assets/tvg-architecture.png"),
+            Path("codex-plugin/mindthus/docs/methodologies/assets/tplan-okr-runtime.png"),
+            Path("codex-plugin/mindthus/docs/methodologies/assets/tvg-architecture.png"),
             Path("opencode/docs/methodologies/assets/tplan-okr-runtime.png"),
             Path("opencode/docs/methodologies/assets/tvg-architecture.png"),
         }
@@ -457,6 +460,22 @@ class PackagingDocsTests(unittest.TestCase):
             self.assertIn("CODEX_HOME", text)
             self.assertIn("skills/mindthus", text)
             self.assertNotIn(".agents/skills/mindthus", text)
+
+    def test_plugin_mode_docs_cover_codex_claude_and_opencode_boundaries(self):
+        install = (REPO / ".codex" / "INSTALL.md").read_text(encoding="utf-8")
+        readme = (REPO / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("Codex plugin mode", install)
+        self.assertIn("skills-pack mode", install)
+        self.assertIn("~/.codex/skills/mindthus", install)
+        self.assertIn("using-mindthus", install)
+        self.assertIn("清楚低风险任务直接执行", install)
+
+        self.assertIn("plugin mode", readme)
+        self.assertIn("/mindthus:using-mindthus", readme)
+        self.assertIn("Claude Code", readme)
+        self.assertIn("OpenCode", readme)
+        self.assertIn("OpenCode 继续使用 skills-pack", readme)
 
     def test_install_script_exists_and_has_valid_shell_syntax(self):
         script = REPO / "scripts" / "install-skills.sh"
@@ -594,6 +613,32 @@ class PackagingDocsTests(unittest.TestCase):
             )
             self.assertIn("python3 skills/mindthus/tvg/scripts/trace/init.py", codex_tvg_skill)
             self.assertNotIn("python3 skills/tvg/scripts/trace/init.py", codex_tvg_skill)
+
+            codex_plugin_root = out / "codex-plugin" / "mindthus"
+            codex_plugin_manifest_path = codex_plugin_root / ".codex-plugin" / "plugin.json"
+            self.assertTrue(codex_plugin_manifest_path.exists())
+            codex_plugin_manifest = json.loads(codex_plugin_manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(codex_plugin_manifest["name"], "mindthus")
+            self.assertEqual(codex_plugin_manifest["version"], "1.1.2")
+            self.assertEqual(codex_plugin_manifest["skills"], "./skills/")
+            self.assertIn("Judgment framework", codex_plugin_manifest["description"])
+            self.assertEqual(
+                codex_plugin_manifest["interface"]["defaultPrompt"],
+                [
+                    "当问题涉及战略判断、结构歧义、路径波动、控制边界、产物价值厚度时，优先使用 using-mindthus 选择最小充分方法；清楚低风险任务直接执行。"
+                ],
+            )
+            self.assertTrue((codex_plugin_root / "skills" / "tplan" / "SKILL.md").exists())
+            self.assertTrue((codex_plugin_root / "skills" / "mpg" / "SKILL.md").exists())
+            self.assertFalse((codex_plugin_root / "skills" / "_runtime").exists())
+            self.assertTrue((codex_plugin_root / "_runtime" / "fidelity" / "core.py").exists())
+            for path in sorted((codex_plugin_root / "skills").glob("*/SKILL.md")):
+                self.assert_skill_frontmatter_is_parseable(path)
+            self.assertTrue((codex_plugin_root / "docs" / "methodologies" / "shared-primitives.md").exists())
+            self.assertTrue((codex_plugin_root / "scripts" / "run-fidelity-judge.py").exists())
+            self.assertFalse((codex_plugin_root / "docs" / "internal").exists())
+            self.assertFalse((codex_plugin_root / "docs" / "superpowers").exists())
+
             self.assertTrue(
                 (out / "opencode" / ".opencode" / "skills" / "mindthus" / "tplan" / "SKILL.md").exists()
             )
@@ -620,6 +665,7 @@ class PackagingDocsTests(unittest.TestCase):
             ).read_text(encoding="utf-8")
             self.assertIn("python3 .opencode/skills/mindthus/tvg/scripts/trace/init.py", opencode_tvg_skill)
             self.assertNotIn("python3 skills/tvg/scripts/trace/init.py", opencode_tvg_skill)
+            self.assertFalse((out / "opencode-plugin").exists())
 
             skill_names = ("3l5s", "sela", "mpg", "edsp", "wae", "tvg", "tplan", "using-mindthus")
             for platform_dir in (out / "codex", out / "opencode"):


### PR DESCRIPTION
## Summary

- Add generated Codex plugin artifact at `codex-plugin/mindthus/` while preserving existing `codex/`, `claude-code/`, and `opencode/` release outputs.
- Keep Claude Code plugin mode on the existing `claude-code/claude-plugin/` artifact and document plugin vs personal-skills invocation differences.
- Keep OpenCode skills-pack-only for now; do not generate `opencode-plugin/`.
- Add router-only light guidance to Codex plugin metadata and docs, without adding a strong startup hook.

## Test Plan

- [x] `python3 -m unittest tests.test_packaging_docs -v` — 22 passed
- [x] `python3 -m unittest discover -s tests -v` — 355 passed
- [x] Build release pack with `scripts/build-release-pack.py`
- [x] Codex plugin validator passed after installing PyYAML in the Codex bundled Python runtime
- [x] Claude Code strict validation passed for generated plugin and marketplace
- [x] Codex CLI smoke passed: temporary marketplace add/list/install enabled `mindthus@mindthus-smoke`

## Notes

The Codex plugin package keeps discoverable skills under `skills/<skill>/SKILL.md` and moves shared runtime support to plugin-root `_runtime/`, so `skills/_runtime` is not exposed as a bogus skill directory.

Closes #57
