### PR TITLE
Release Mindthus v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@
 
 暂无。
 
+## v1.2.0
+
+发布日期：2026-06-24
+
+[完整发布日志](docs/releases/v1.2.0.md)
+
+说明：本版把 Mindthus 从单一 skills-pack 分发，扩展为 Codex / Claude Code 可识别的插件产品壳，同时保留 `skills/` 作为唯一行为源码。Codex 新增 `codex-plugin/mindthus` release artifact；Claude Code 继续使用既有 plugin artifact；OpenCode 继续使用 skills-pack，不用 command、hook 或 custom tool 模拟 native skills。插件里的提示只是一句 router-only 纪律，不是强制 startup hook。
+
+### 新增
+
+- Codex plugin packaging：release builder 新增 `codex-plugin/mindthus/`，包含 `.codex-plugin/plugin.json`、同源 `skills/`、公开 methodology docs、license 和 release scripts。
+- Claude Code plugin 文档化：明确 `claude-code/claude-plugin/` 是插件模式，Claude Code plugin mode 使用 `/mindthus:using-mindthus` 这样的命名空间；personal skills mode 仍是 `/<skill>` 或自动调用。
+- 轻量 router-only 指引：Codex plugin metadata 可以注入一句路由纪律，提醒战略判断、结构歧义、路径波动、控制边界和产物价值厚度问题优先用 `using-mindthus` 选择最小充分方法；清楚低风险任务直接执行。
+
+### 修复
+
+- Codex plugin 的 discoverable `skills/` 目录只包含真正的 skill；共享 runtime support 放在 plugin root 的 `_runtime/`，避免 `skills/_runtime` 被识别成缺少 `SKILL.md` 的伪 skill。
+- release packaging tests 增加 Codex plugin manifest、artifact cleanliness、OpenCode plugin 缺省不生成、以及 plugin / skills-pack 文档边界检查。
+
+### 边界
+
+- OpenCode 继续使用 skills-pack。当前不发布 `opencode-plugin/`，因为 OpenCode plugin API 尚未验证能原生贡献 `SKILL.md` skills；不会用 hook、command 或 custom tool 模拟 native skills。
+- plugin packaging 是 distribution shell，不是 skills fork。`skills/` 仍是唯一行为源码。
+- router-only 指引不能替代事实补充、证据约束或 agentic judgment，也不能强制低风险确定性任务进入 Mindthus。
+
+### 验证
+
+- `python3 -m unittest tests.test_packaging_docs -v`
+- `python3 -m unittest discover -s tests -v`
+- `python3 scripts/build-release-pack.py --out /tmp/mindthus-v1.2.0-check --force`
+- Codex plugin validator passed for generated `codex-plugin/mindthus`.
+- Claude Code strict validation passed for generated plugin and marketplace.
+- Codex CLI smoke passed: temporary marketplace add / list / install enabled `mindthus@mindthus-smoke`.
+
 ## v1.1.2
 
 发布日期：2026-06-23

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ python3 scripts/log-fidelity-usage.py --help
 
 ## 版本与许可
 
-当前仓库版本：`v1.1.2`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
+当前仓库版本：`v1.2.0`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
 
 Mindthus uses AGPLv3 + commercial dual licensing.
 

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -1,0 +1,126 @@
+# Mindthus v1.2.0 发布日志
+
+发布日期：2026-06-24
+
+## 版本定位
+
+`v1.2.0` 是一次 plugin packaging release。它不改变 Mindthus 方法语义，而是把现有 `skills/` 内核包装成 Codex 和 Claude Code 更容易识别、安装和管理的插件产品形态。
+
+这版的核心边界是：
+
+```text
+skills/ is the behavior kernel.
+plugin packaging is the product shell.
+```
+
+也就是说，插件不是第二份方法实现，不重命名 skills，不把 OpenCode 强行插件化，也不增加强制 startup hook。
+
+## 新增
+
+### Codex plugin packaging
+
+Release pack 现在会生成：
+
+```text
+codex-plugin/mindthus/
+  .codex-plugin/plugin.json
+  skills/<skill>/SKILL.md
+  _runtime/
+  docs/methodologies/
+  scripts/
+  LICENSE
+  COMMERCIAL-LICENSE.md
+```
+
+`codex-plugin/mindthus` 让 Codex App 可以把 Mindthus 作为一个插件产品识别和安装，而不是只通过 skills-pack 路径发现 `mindthus:*` skills。
+
+Codex plugin metadata 包含一条轻量 router-only 指引：
+
+```text
+当问题涉及战略判断、结构歧义、路径波动、控制边界、产物价值厚度时，优先使用 using-mindthus 选择最小充分方法；清楚低风险任务直接执行。
+```
+
+这条指引只提醒 agent 何时考虑路由，不是强制 startup hook。清楚、低风险、事实足够的任务仍然应该直接执行。
+
+### Claude Code plugin 边界说明
+
+Claude Code plugin artifact 继续使用既有布局：
+
+```text
+claude-code/
+  .claude-plugin/marketplace.json
+  claude-plugin/
+    .claude-plugin/plugin.json
+    skills/<skill>/SKILL.md
+```
+
+Claude Code plugin mode 下，skills 带插件命名空间，例如 `/mindthus:using-mindthus`。这和 personal skills mode 不同；personal skills mode 通常暴露为 `/<skill>`，或由 Claude 根据 skill description 自动调用。
+
+### OpenCode 继续使用 skills-pack
+
+OpenCode 继续使用：
+
+```text
+opencode/.opencode/skills/mindthus/<skill>/SKILL.md
+```
+
+OpenCode 虽然有 plugin system，但当前没有验证过插件能原生贡献 `SKILL.md` skills，并保持 native skill discovery、permission 和 progressive-disclosure 语义。因此本版不发布 `opencode-plugin/`，也不用 command、hook 或 custom tool 模拟 native skills。
+
+## 修复
+
+### Codex plugin skills 目录纯净化
+
+初版 smoke test 暴露出一个真实问题：共享 runtime support `_runtime` 如果放在 `skills/_runtime`，Codex plugin validator 会把它当成缺少 `SKILL.md` 的伪 skill。
+
+本版最终形态是：
+
+- `skills/` 只放真正的 method skills；
+- `_runtime/` 放在 plugin root；
+- validators 和 helper scripts 仍可随包使用共享 runtime support；
+- packaging tests 明确锁住 `skills/_runtime` 不存在、`_runtime/fidelity/core.py` 存在。
+
+### Release pack 守卫
+
+Packaging tests 现在覆盖：
+
+- Codex plugin manifest version、`skills` 指向和 router-only default prompt；
+- Codex plugin artifact 的 public docs、scripts、licenses 和 skill frontmatter；
+- release pack 仍排除 `docs/internal/`、`docs/superpowers/`、tests、logs、runtime files 和临时产物；
+- `opencode-plugin/` 缺省不生成。
+
+## 边界
+
+- `v1.2.0` 不重写任何 Mindthus skill 的方法语义。
+- `v1.2.0` 不移除 skills-pack installer。
+- `v1.2.0` 不声明 OpenCode plugin mode 已支持。
+- `v1.2.0` 不声明 OpenAI curated Plugin Directory、Claude marketplace 或 OpenCode marketplace 官方收录。
+- router-only 指引不能替代事实补充、证据约束、运行时验证或 agentic judgment。
+
+## 验证
+
+本次发布准备通过：
+
+```bash
+python3 -m unittest tests.test_packaging_docs -v
+python3 -m unittest discover -s tests -v
+python3 scripts/build-release-pack.py --out /tmp/mindthus-v1.2.0-check --force
+```
+
+本机插件 smoke test 通过：
+
+```bash
+claude plugin validate /tmp/mindthus-v1.2.0-check/claude-code/claude-plugin --strict
+claude plugin validate /tmp/mindthus-v1.2.0-check/claude-code --strict
+codex plugin marketplace add <temporary-marketplace> --json
+codex plugin list --marketplace mindthus-smoke --available --json
+codex plugin add mindthus@mindthus-smoke --json
+```
+
+额外确认：
+
+- Codex plugin validator passed for generated `codex-plugin/mindthus`;
+- generated Codex plugin cache contains `.codex-plugin/plugin.json`;
+- generated Codex plugin cache contains `skills/using-mindthus/SKILL.md`;
+- generated Codex plugin cache does not contain `skills/_runtime`;
+- generated Codex plugin cache contains plugin-root `_runtime/fidelity/core.py`;
+- generated release pack does not contain `opencode-plugin/`.

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -9,7 +9,7 @@ import shutil
 from pathlib import Path
 
 
-VERSION = "1.1.2"
+VERSION = "1.2.0"
 EXCLUDED_DIRS = {
     "__pycache__",
     ".pytest_cache",

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -54,7 +54,7 @@ class PackagingDocsTests(unittest.TestCase):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         self.assertIn("mindthus:tplan", readme)
         self.assertIn("mindthus:*", readme)
-        self.assertIn("当前仓库版本：`v1.1.2`", readme)
+        self.assertIn("当前仓库版本：`v1.2.0`", readme)
         self.assertIn("scripts/log-fidelity-usage.py", readme)
         self.assertIn("data/fidelity-usage-log.jsonl", readme)
         self.assertIn("AGPLv3 + commercial dual licensing", readme)
@@ -567,7 +567,7 @@ class PackagingDocsTests(unittest.TestCase):
             source = marketplace["plugins"][0]["source"]
             self.assertEqual(source, "./claude-plugin")
             self.assertNotIn("..", source)
-            self.assertEqual(plugin["version"], "1.1.2")
+            self.assertEqual(plugin["version"], "1.2.0")
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "tplan" / "SKILL.md").exists())
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "mpg" / "SKILL.md").exists())
             for path in sorted((out / "claude-code" / "claude-plugin" / "skills").glob("*/SKILL.md")):
@@ -619,7 +619,7 @@ class PackagingDocsTests(unittest.TestCase):
             self.assertTrue(codex_plugin_manifest_path.exists())
             codex_plugin_manifest = json.loads(codex_plugin_manifest_path.read_text(encoding="utf-8"))
             self.assertEqual(codex_plugin_manifest["name"], "mindthus")
-            self.assertEqual(codex_plugin_manifest["version"], "1.1.2")
+            self.assertEqual(codex_plugin_manifest["version"], "1.2.0")
             self.assertEqual(codex_plugin_manifest["skills"], "./skills/")
             self.assertIn("Judgment framework", codex_plugin_manifest["description"])
             self.assertEqual(

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -6,23 +6,55 @@ REPO = Path(__file__).resolve().parents[1]
 
 
 class ReleaseBoundaryContractTests(unittest.TestCase):
-    def test_current_release_surface_is_v1_1_2(self):
+    def test_current_release_surface_is_v1_2_0(self):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
         builder = (REPO / "scripts" / "build-release-pack.py").read_text(encoding="utf-8")
 
-        self.assertIn("当前仓库版本：`v1.1.2`", readme)
+        self.assertIn("当前仓库版本：`v1.2.0`", readme)
         self.assertEqual(readme.count("当前仓库版本："), 1)
-        self.assertNotIn("当前仓库版本：`v0.6.3`", readme)
+        self.assertNotIn("当前仓库版本：`v1.1.2`", readme)
         self.assertNotIn("## 版本与开发状态", readme)
         self.assertNotIn("当前开发分支同步", readme)
+        self.assertIn("## v1.2.0", changelog)
+        self.assertIn("[完整发布日志](docs/releases/v1.2.0.md)", changelog)
+        self.assertIn("Codex plugin packaging", changelog)
+        self.assertIn("Claude Code plugin", changelog)
+        self.assertIn("OpenCode 继续使用 skills-pack", changelog)
+        self.assertIn("router-only", changelog)
+        self.assertIn('VERSION = "1.2.0"', builder)
+
+        release_log = (REPO / "docs" / "releases" / "v1.2.0.md").read_text(
+            encoding="utf-8"
+        )
+        for phrase in (
+            "# Mindthus v1.2.0 发布日志",
+            "发布日期：2026-06-24",
+            "Codex plugin packaging",
+            "codex-plugin/mindthus",
+            "Claude Code plugin",
+            "/mindthus:using-mindthus",
+            "OpenCode 继续使用 skills-pack",
+            "router-only",
+            "skills/_runtime",
+            "_runtime/",
+            "1.2.0",
+            "python3 scripts/build-release-pack.py",
+            "claude plugin validate",
+            "codex plugin add mindthus@mindthus-smoke",
+        ):
+            self.assertIn(phrase, release_log)
+
+        self.assertNotIn("Release date:", release_log)
+
+    def test_v1_1_2_release_surface_is_preserved(self):
+        changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## v1.1.2", changelog)
         self.assertIn("[完整发布日志](docs/releases/v1.1.2.md)", changelog)
         self.assertIn("Snapshot / Pulse / Gate", changelog)
         self.assertIn("Mission Pulse", changelog)
         self.assertIn("minimum-pairs", changelog)
         self.assertIn("不声明低频方法 wake-up lift 已被真实 replay 证明", changelog)
-        self.assertIn('VERSION = "1.1.2"', builder)
 
         release_log = (REPO / "docs" / "releases" / "v1.1.2.md").read_text(
             encoding="utf-8"

--- a/tests/test_v0_9_acceptance.py
+++ b/tests/test_v0_9_acceptance.py
@@ -30,7 +30,7 @@ class V09AcceptanceTests(unittest.TestCase):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
 
-        for phrase in ("v1.1.2", "GitHub Releases"):
+        for phrase in ("当前仓库版本：`v1.2.0`", "GitHub Releases"):
             self.assertIn(phrase, readme)
 
         for phrase in (

--- a/tests/test_v1_0_1_usage_log.py
+++ b/tests/test_v1_0_1_usage_log.py
@@ -145,7 +145,7 @@ class V101UsageLogTests(unittest.TestCase):
         )
 
         for phrase in (
-            "当前仓库版本：`v1.1.2`",
+            "当前仓库版本：`v1.2.0`",
             "scripts/log-fidelity-usage.py",
             "data/fidelity-usage-log.jsonl",
             "可选：记录使用效果",
@@ -174,7 +174,7 @@ class V101UsageLogTests(unittest.TestCase):
                     / "plugin.json"
                 ).read_text(encoding="utf-8")
             )
-            self.assertEqual(plugin["version"], "1.1.2")
+            self.assertEqual(plugin["version"], "1.2.0")
             for platform_root in (
                 root / "claude-code" / "claude-plugin",
                 root / "codex",

--- a/tests/test_v1_0_readiness.py
+++ b/tests/test_v1_0_readiness.py
@@ -106,7 +106,7 @@ class V10ReadinessTests(unittest.TestCase):
 
         self.assertIn("AGPLv3 + commercial dual licensing", readme)
         self.assertIn("closed-source commercial use requires a separate commercial license", readme)
-        self.assertIn("当前仓库版本：`v1.1.2`", readme)
+        self.assertIn("当前仓库版本：`v1.2.0`", readme)
         self.assertNotIn("Pre-1.0", readme)
 
     def test_release_pack_carries_license_judge_script_and_rubric(self):


### PR DESCRIPTION
## Summary
- Bump release metadata and release builder version to v1.2.0.
- Add the v1.2.0 release log for Codex / Claude Code plugin packaging, router-only guidance, and OpenCode skills-pack boundary.
- Update release-boundary tests so current docs target v1.2.0 while preserving v1.1.2 history.

## Verification
- [x] `python3 -m unittest tests.test_v0_9_acceptance tests.test_release_boundary_contract tests.test_packaging_docs tests.test_v1_0_readiness tests.test_v1_0_1_usage_log -v`
- [x] `python3 -m unittest discover -s tests -v` (356 tests)
- [x] `python3 scripts/build-release-pack.py --out <tmp>/release`
- [x] Codex plugin validator passed for generated `codex-plugin/mindthus`
- [x] `claude plugin validate <release>/claude-code/claude-plugin --strict`
- [x] `claude plugin validate <release>/claude-code --strict`
- [x] Codex CLI smoke: temporary marketplace add / list / install for `mindthus@mindthus-smoke`, installed cache version `1.2.0`
- [x] Confirmed generated release pack does not contain `opencode-plugin/`