### PR TITLE
Finalize v1.2.0 release package installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- README 安装说明补全：明确 Codex / Claude Code 推荐 plugin mode，开发调试和 OpenCode 使用 skills-pack mode，并给出可执行安装、更新和卸载命令。
-- Codex plugin release pack 新增 `.agents/plugins/marketplace.json`，使 `codex plugin marketplace add <release>/codex-plugin` 后可以直接 `codex plugin add mindthus@mindthus`。
+暂无。
 
 ## v1.2.0
 
@@ -11,12 +10,14 @@
 
 [完整发布日志](docs/releases/v1.2.0.md)
 
-说明：本版把 Mindthus 从单一 skills-pack 分发，扩展为 Codex / Claude Code 可识别的插件产品壳，同时保留 `skills/` 作为唯一行为源码。Codex 新增 `codex-plugin/mindthus` release artifact；Claude Code 继续使用既有 plugin artifact；OpenCode 继续使用 skills-pack，不用 command、hook 或 custom tool 模拟 native skills。插件里的提示只是一句 router-only 纪律，不是强制 startup hook。
+说明：本版把 Mindthus 从单一 skills-pack 分发，扩展为 Codex / Claude Code 可识别的插件产品壳，同时保留 `skills/` 作为唯一行为源码。推荐安装入口是 GitHub Release 里的预构建 release pack；Codex / Claude Code plugin mode 和 skills-pack mode 都从同一个 release pack 安装。Codex 新增 `codex-plugin/mindthus` release artifact；Claude Code 继续使用既有 plugin artifact；OpenCode 继续使用 skills-pack，不用 command、hook 或 custom tool 模拟 native skills。插件里的提示只是一句 router-only 纪律，不是强制 startup hook。
 
 ### 新增
 
 - Codex plugin packaging：release builder 新增 `codex-plugin/mindthus/`，包含 `.codex-plugin/plugin.json`、同源 `skills/`、公开 methodology docs、license 和 release scripts。
 - Claude Code plugin 文档化：明确 `claude-code/claude-plugin/` 是插件模式，Claude Code plugin mode 使用 `/mindthus:using-mindthus` 这样的命名空间；personal skills mode 仍是 `/<skill>` 或自动调用。
+- README 安装说明改为 release-pack-first：先下载 `mindthus-release-1.2.0.tar.gz`，解压到 `/tmp/mindthus-release`，再按 Codex plugin、Claude Code plugin、Codex skills-pack、Claude personal skills 或 OpenCode skills-pack 安装；源码 clone 只作为开发者 fallback。
+- Codex plugin release pack 新增 `.agents/plugins/marketplace.json`，使 `codex plugin marketplace add <release>/codex-plugin` 后可以直接 `codex plugin add mindthus@mindthus`。
 - 轻量 router-only 指引：Codex plugin metadata 可以注入一句路由纪律，提醒战略判断、结构歧义、路径波动、控制边界和产物价值厚度问题优先用 `using-mindthus` 选择最小充分方法；清楚低风险任务直接执行。
 
 ### 修复
@@ -34,7 +35,7 @@
 
 - `python3 -m unittest tests.test_packaging_docs -v`
 - `python3 -m unittest discover -s tests -v`
-- `python3 scripts/build-release-pack.py --out /tmp/mindthus-v1.2.0-check --force`
+- `python3 scripts/build-release-pack.py --out /tmp/mindthus-release --force`
 - Codex plugin validator passed for generated `codex-plugin/mindthus`.
 - Claude Code strict validation passed for generated plugin and marketplace.
 - Codex CLI smoke passed: temporary marketplace add / list / install enabled `mindthus@mindthus-smoke`.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,21 @@ Mindthus 有两种安装形态，推荐顺序很简单：
 
 同一个 client profile 里不要同时启用 plugin mode 和 skills-pack mode，除非你明确想测试重复 discovery。迁移到 plugin mode 前，先移除旧的 skills-pack symlink。
 
-先准备一份 release pack：
+先下载 release pack。普通用户不需要 clone 仓库：
+
+```bash
+VERSION=1.2.0
+curl -L \
+  -o /tmp/mindthus-release-${VERSION}.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-release-${VERSION}.tar.gz"
+rm -rf /tmp/mindthus-release
+mkdir -p /tmp/mindthus-release
+tar -xzf /tmp/mindthus-release-${VERSION}.tar.gz -C /tmp/mindthus-release --strip-components=1
+```
+
+当前 release asset 名称是 `mindthus-release-1.2.0.tar.gz`。
+
+如果你正在开发 Mindthus，才需要从源码构建同样结构的 release pack：
 
 ```bash
 git clone https://github.com/rv198-star/Mindthus.git ~/mindthus
@@ -146,19 +160,27 @@ claude plugin marketplace remove mindthus
 
 ### Codex Skills-Pack Mode
 
-在已有 checkout 中安装或刷新技能包：
+release pack 里也包含 Codex skills-pack 形态。这个方式适合不能使用插件管理、需要 portable checkout，或想保留 `mindthus:*` skills namespace 的环境。
+
+```bash
+rm -rf "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+cp -R /tmp/mindthus-release/codex/skills/mindthus "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
+```
+
+重启 Codex 后，可以通过 `mindthus:*` 命名空间使用这些 skills，例如 `mindthus:tplan`。
+
+如果你是开发者，并希望 skills 直接跟随当前 checkout，可以改用 symlink installer：
 
 ```bash
 cd ~/mindthus
 scripts/install-skills.sh codex --force
 ```
 
-这会创建 `${CODEX_HOME:-~/.codex}/skills/mindthus -> <repo>/skills`。重启 Codex 后，可以通过 `mindthus:*` 命名空间使用这些 skills，例如 `mindthus:tplan`。
-
-这个方式适合开发者，因为 symlink 会直接指向当前 checkout；拉取新代码后重启 Codex 即可读到更新。卸载：
+卸载：
 
 ```bash
-rm "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
+rm -rf "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
 ```
 
 详细说明见 [.codex/INSTALL.md](.codex/INSTALL.md)。
@@ -166,16 +188,27 @@ rm "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
 ### Claude Code Personal Skills Mode
 
 ```bash
-cd ~/mindthus
-scripts/install-skills.sh claude --force
+mkdir -p ~/.claude/skills
+for skill in /tmp/mindthus-release/claude-code/claude-plugin/skills/*; do
+  [ -f "$skill/SKILL.md" ] || continue
+  rm -rf "$HOME/.claude/skills/$(basename "$skill")"
+  cp -R "$skill" "$HOME/.claude/skills/"
+done
 ```
 
 这会把同一套 `skills/` 安装到 Claude Code personal skills 路径。personal skills mode 不会增加 `mindthus:` plugin namespace，通常暴露为 `/<skill>`，或由 Claude 根据 skill description 自动调用。
 
+开发者也可以用 checkout symlink installer：
+
+```bash
+cd ~/mindthus
+scripts/install-skills.sh claude --force
+```
+
 卸载：
 
 ```bash
-rm -rf ~/.claude/skills/mindthus
+rm -rf ~/.claude/skills/{3l5s,edsp,mpg,sela,tplan,tvg,using-mindthus,wae}
 ```
 
 ### OpenCode

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -6,6 +6,8 @@
 
 `v1.2.0` 是一次 plugin packaging release。它不改变 Mindthus 方法语义，而是把现有 `skills/` 内核包装成 Codex 和 Claude Code 更容易识别、安装和管理的插件产品形态。
 
+本版的默认安装入口是 GitHub Release 里的预构建 release pack，而不是要求普通用户 clone 仓库再 build。源码 clone 仍然保留，但只作为开发者 fallback。
+
 这版的核心边界是：
 
 ```text
@@ -14,6 +16,24 @@ plugin packaging is the product shell.
 ```
 
 也就是说，插件不是第二份方法实现，不重命名 skills，不把 OpenCode 强行插件化，也不增加强制 startup hook。
+
+## 安装入口
+
+普通用户先下载 release asset：
+
+```bash
+VERSION=1.2.0
+curl -L \
+  -o /tmp/mindthus-release-${VERSION}.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-release-${VERSION}.tar.gz"
+rm -rf /tmp/mindthus-release
+mkdir -p /tmp/mindthus-release
+tar -xzf /tmp/mindthus-release-${VERSION}.tar.gz -C /tmp/mindthus-release --strip-components=1
+```
+
+本次 release asset 名称是 `mindthus-release-1.2.0.tar.gz`。
+
+解压后，Codex plugin、Claude Code plugin、Codex skills-pack、Claude personal skills 和 OpenCode skills-pack 都从 `/tmp/mindthus-release` 安装。
 
 ## 新增
 
@@ -33,6 +53,19 @@ codex-plugin/mindthus/
 ```
 
 `codex-plugin/mindthus` 让 Codex App 可以把 Mindthus 作为一个插件产品识别和安装，而不是只通过 skills-pack 路径发现 `mindthus:*` skills。
+
+Codex plugin release pack 同时包含 marketplace manifest：
+
+```text
+codex-plugin/.agents/plugins/marketplace.json
+```
+
+因此可以直接运行：
+
+```bash
+codex plugin marketplace add /tmp/mindthus-release/codex-plugin
+codex plugin add mindthus@mindthus
+```
 
 Codex plugin metadata 包含一条轻量 router-only 指引：
 
@@ -84,6 +117,7 @@ OpenCode 虽然有 plugin system，但当前没有验证过插件能原生贡献
 Packaging tests 现在覆盖：
 
 - Codex plugin manifest version、`skills` 指向和 router-only default prompt；
+- Codex plugin marketplace manifest，使 `codex plugin marketplace add <release>/codex-plugin` 可以直接发现 `mindthus@mindthus`；
 - Codex plugin artifact 的 public docs、scripts、licenses 和 skill frontmatter；
 - release pack 仍排除 `docs/internal/`、`docs/superpowers/`、tests、logs、runtime files 和临时产物；
 - `opencode-plugin/` 缺省不生成。
@@ -103,14 +137,16 @@ Packaging tests 现在覆盖：
 ```bash
 python3 -m unittest tests.test_packaging_docs -v
 python3 -m unittest discover -s tests -v
-python3 scripts/build-release-pack.py --out /tmp/mindthus-v1.2.0-check --force
+python3 scripts/build-release-pack.py --out /tmp/mindthus-release --force
 ```
 
 本机插件 smoke test 通过：
 
 ```bash
-claude plugin validate /tmp/mindthus-v1.2.0-check/claude-code/claude-plugin --strict
-claude plugin validate /tmp/mindthus-v1.2.0-check/claude-code --strict
+claude plugin validate /tmp/mindthus-release/claude-code/claude-plugin --strict
+claude plugin validate /tmp/mindthus-release/claude-code --strict
+claude plugin marketplace add /tmp/mindthus-release/claude-code
+claude plugin install mindthus@mindthus
 codex plugin marketplace add <temporary-marketplace> --json
 codex plugin list --marketplace mindthus-smoke --available --json
 codex plugin add mindthus@mindthus-smoke --json
@@ -124,3 +160,4 @@ codex plugin add mindthus@mindthus-smoke --json
 - generated Codex plugin cache does not contain `skills/_runtime`;
 - generated Codex plugin cache contains plugin-root `_runtime/fidelity/core.py`;
 - generated release pack does not contain `opencode-plugin/`.
+- release asset packaged as `mindthus-release-1.2.0.tar.gz`.

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -16,12 +16,16 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         self.assertNotIn("当前仓库版本：`v1.1.2`", readme)
         self.assertNotIn("## 版本与开发状态", readme)
         self.assertNotIn("当前开发分支同步", readme)
+        self.assertIn("VERSION=1.2.0", readme)
+        self.assertIn("mindthus-release-${VERSION}.tar.gz", readme)
+        self.assertIn("mindthus-release-1.2.0.tar.gz", readme)
+        self.assertIn("github.com/rv198-star/Mindthus/releases/download/v${VERSION}", readme)
+        self.assertIn("codex plugin marketplace add /tmp/mindthus-release/codex-plugin", readme)
+        self.assertIn("claude plugin marketplace add /tmp/mindthus-release/claude-code", readme)
+        self.assertIn("cp -R /tmp/mindthus-release/opencode/.opencode", readme)
         self.assertIn("## v1.2.0", changelog)
         self.assertIn("[完整发布日志](docs/releases/v1.2.0.md)", changelog)
-        self.assertIn("Codex plugin packaging", changelog)
-        self.assertIn("Claude Code plugin", changelog)
-        self.assertIn("OpenCode 继续使用 skills-pack", changelog)
-        self.assertIn("router-only", changelog)
+        self.assertIn("release-pack-first", changelog)
         self.assertIn('VERSION = "1.2.0"', builder)
 
         release_log = (REPO / "docs" / "releases" / "v1.2.0.md").read_text(
@@ -30,6 +34,11 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         for phrase in (
             "# Mindthus v1.2.0 发布日志",
             "发布日期：2026-06-24",
+            "release pack",
+            "mindthus-release-1.2.0.tar.gz",
+            "codex-plugin/.agents/plugins/marketplace.json",
+            "codex plugin add mindthus@mindthus",
+            "claude plugin install mindthus@mindthus",
             "Codex plugin packaging",
             "codex-plugin/mindthus",
             "Claude Code plugin",


### PR DESCRIPTION
## Summary
- Make v1.2.0 release-pack-first: README now starts from the GitHub Release asset `mindthus-release-1.2.0.tar.gz` instead of clone/build.
- Fold Codex / Claude Code plugin install and skills-pack install instructions into the v1.2.0 release notes.
- Keep source clone/build only as a developer fallback.

## Release handling
- The previous v1.2.0 GitHub Release and tag were removed because they had no release asset and pointed before the final install docs.
- After this PR merges, v1.2.0 should be recreated from the new main commit with `mindthus-release-1.2.0.tar.gz` uploaded.

## Verification
- [x] `python3 -m unittest tests.test_release_boundary_contract tests.test_packaging_docs tests.test_v1_0_readiness tests.test_v1_0_1_usage_log tests.test_v0_9_acceptance -v`
- [x] `python3 -m unittest discover -s tests -v` (356 tests)
- [x] `python3 scripts/build-release-pack.py --out /tmp/mindthus-release --force`
- [x] Codex plugin validator passed for generated `codex-plugin/mindthus`
- [x] Claude Code strict validation passed for generated plugin and marketplace
- [x] Codex CLI smoke: `codex plugin marketplace add /tmp/mindthus-release/codex-plugin` then `codex plugin add mindthus@mindthus`
- [x] Claude Code smoke with temporary HOME: marketplace add / install / list for `mindthus@mindthus`
- [x] Archive smoke: `mindthus-release-1.2.0.tar.gz` contains Codex, Claude Code, and OpenCode install surfaces