### PR TITLE
release: split and slim v1.2.0 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@
 
 [完整发布日志](docs/releases/v1.2.0.md)
 
-说明：本版把 Mindthus 从单一 skills-pack 分发，扩展为 Codex / Claude Code 可识别的插件产品壳，同时保留 `skills/` 作为唯一行为源码。推荐安装入口是 GitHub Release 里的预构建 release pack；Codex / Claude Code plugin mode 和 skills-pack mode 都从同一个 release pack 安装。Codex 新增 `codex-plugin/mindthus` release artifact；Claude Code 继续使用既有 plugin artifact；OpenCode 继续使用 skills-pack，不用 command、hook 或 custom tool 模拟 native skills。插件里的提示只是一句 router-only 纪律，不是强制 startup hook。
+说明：本版把 Mindthus 从单一 skills-pack 分发，扩展为 Codex / Claude Code 可识别的插件产品壳，同时保留 `skills/` 作为唯一行为源码。推荐安装入口是 GitHub Release 里的预构建 release pack；plugin mode 使用 `mindthus-plugins-1.2.0.tar.gz`，skills-pack mode 使用 `mindthus-skills-1.2.0.tar.gz`。Codex 新增 `codex-plugin/mindthus` release artifact；Claude Code 继续使用既有 plugin artifact；OpenCode 继续使用 skills-pack，不用 command、hook 或 custom tool 模拟 native skills。插件里的提示只是一句 router-only 纪律，不是强制 startup hook。
 
 ### 新增
 
 - Codex plugin packaging：release builder 新增 `codex-plugin/mindthus/`，包含 `.codex-plugin/plugin.json`、同源 `skills/`、公开 methodology docs、license 和 release scripts。
 - Claude Code plugin 文档化：明确 `claude-code/claude-plugin/` 是插件模式，Claude Code plugin mode 使用 `/mindthus:using-mindthus` 这样的命名空间；personal skills mode 仍是 `/<skill>` 或自动调用。
-- README 安装说明改为 release-pack-first：先下载 `mindthus-release-1.2.0.tar.gz`，解压到 `/tmp/mindthus-release`，再按 Codex plugin、Claude Code plugin、Codex skills-pack、Claude personal skills 或 OpenCode skills-pack 安装；源码 clone 只作为开发者 fallback。
+- README 安装说明改为 release-pack-first：plugin mode 下载 `mindthus-plugins-1.2.0.tar.gz`，skills-pack mode 下载 `mindthus-skills-1.2.0.tar.gz`；源码 clone 只作为开发者 fallback。
 - Codex plugin release pack 新增 `.agents/plugins/marketplace.json`，使 `codex plugin marketplace add <release>/codex-plugin` 后可以直接 `codex plugin add mindthus@mindthus`。
 - 轻量 router-only 指引：Codex plugin metadata 可以注入一句路由纪律，提醒战略判断、结构歧义、路径波动、控制边界和产物价值厚度问题优先用 `using-mindthus` 选择最小充分方法；清楚低风险任务直接执行。
 
@@ -24,6 +24,8 @@
 
 - Codex plugin 的 discoverable `skills/` 目录只包含真正的 skill；共享 runtime support 放在 plugin root 的 `_runtime/`，避免 `skills/_runtime` 被识别成缺少 `SKILL.md` 的伪 skill。
 - release packaging tests 增加 Codex plugin manifest、artifact cleanliness、OpenCode plugin 缺省不生成、以及 plugin / skills-pack 文档边界检查。
+- release packaging 改为插件包和 skills 包分离：Codex + Claude Code 插件合在 `mindthus-plugins-1.2.0.tar.gz`；Codex + Claude Code + OpenCode skills-pack 合在 `mindthus-skills-1.2.0.tar.gz`。
+- release pack 不再携带 methodology 文档图片等二进制大图资产；图文版文档保留在 GitHub 仓库和官网文档入口。
 
 ### 边界
 
@@ -35,7 +37,8 @@
 
 - `python3 -m unittest tests.test_packaging_docs -v`
 - `python3 -m unittest discover -s tests -v`
-- `python3 scripts/build-release-pack.py --out /tmp/mindthus-release --force`
+- `python3 scripts/build-release-pack.py --package plugins --out /tmp/mindthus-plugins --force`
+- `python3 scripts/build-release-pack.py --package skills --out /tmp/mindthus-skills --force`
 - Codex plugin validator passed for generated `codex-plugin/mindthus`.
 - Claude Code strict validation passed for generated plugin and marketplace.
 - Codex CLI smoke passed: temporary marketplace add / list / install enabled `mindthus@mindthus-smoke`.

--- a/README.md
+++ b/README.md
@@ -92,34 +92,47 @@ Mindthus 有两种安装形态，推荐顺序很简单：
 
 同一个 client profile 里不要同时启用 plugin mode 和 skills-pack mode，除非你明确想测试重复 discovery。迁移到 plugin mode 前，先移除旧的 skills-pack symlink。
 
-先下载 release pack。普通用户不需要 clone 仓库：
+普通用户不需要 clone 仓库。优先按用途下载 release pack：
+
+- plugin mode：下载 `mindthus-plugins-${VERSION}.tar.gz`，包含 Codex plugin 和 Claude Code plugin。
+- skills-pack mode：下载 `mindthus-skills-${VERSION}.tar.gz`，包含 Codex、Claude Code personal skills 和 OpenCode 的 skills-pack 布局。
+
+release pack 不携带 methodology 文档里的大图资产；需要看图文版文档时，直接读 GitHub 仓库或官网文档。
 
 ```bash
 VERSION=1.2.0
 curl -L \
-  -o /tmp/mindthus-release-${VERSION}.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-release-${VERSION}.tar.gz"
-rm -rf /tmp/mindthus-release
-mkdir -p /tmp/mindthus-release
-tar -xzf /tmp/mindthus-release-${VERSION}.tar.gz -C /tmp/mindthus-release --strip-components=1
+  -o /tmp/mindthus-plugins-${VERSION}.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-plugins-${VERSION}.tar.gz"
+rm -rf /tmp/mindthus-plugins
+mkdir -p /tmp/mindthus-plugins
+tar -xzf /tmp/mindthus-plugins-${VERSION}.tar.gz -C /tmp/mindthus-plugins --strip-components=1
+
+curl -L \
+  -o /tmp/mindthus-skills-${VERSION}.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-skills-${VERSION}.tar.gz"
+rm -rf /tmp/mindthus-skills
+mkdir -p /tmp/mindthus-skills
+tar -xzf /tmp/mindthus-skills-${VERSION}.tar.gz -C /tmp/mindthus-skills --strip-components=1
 ```
 
-当前 release asset 名称是 `mindthus-release-1.2.0.tar.gz`。
+当前 release asset 名称是 `mindthus-plugins-1.2.0.tar.gz` 和 `mindthus-skills-1.2.0.tar.gz`。
 
 如果你正在开发 Mindthus，才需要从源码构建同样结构的 release pack：
 
 ```bash
 git clone https://github.com/rv198-star/Mindthus.git ~/mindthus
 cd ~/mindthus
-python3 scripts/build-release-pack.py --out /tmp/mindthus-release --force
+python3 scripts/build-release-pack.py --package plugins --out /tmp/mindthus-plugins --force
+python3 scripts/build-release-pack.py --package skills --out /tmp/mindthus-skills --force
 ```
 
 ### Codex Plugin Mode（推荐）
 
-Codex plugin mode 使用 release pack 里的 `codex-plugin/` marketplace。安装后，Codex 通过插件管理 Mindthus，并读取插件内同源的 `skills/`。
+Codex plugin mode 使用 plugins release pack 里的 `codex-plugin/` marketplace。安装后，Codex 通过插件管理 Mindthus，并读取插件内同源的 `skills/`。
 
 ```bash
-codex plugin marketplace add /tmp/mindthus-release/codex-plugin
+codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin
 codex plugin list --marketplace mindthus --available
 codex plugin add mindthus@mindthus
 codex plugin list
@@ -136,10 +149,10 @@ codex plugin marketplace remove mindthus
 
 ### Claude Code Plugin Mode（推荐）
 
-Claude Code plugin mode 使用 release pack 里的 `claude-code/` marketplace。安装后，skills 带插件命名空间，例如 `/mindthus:using-mindthus`。
+Claude Code plugin mode 使用 plugins release pack 里的 `claude-code/` marketplace。安装后，skills 带插件命名空间，例如 `/mindthus:using-mindthus`。
 
 ```bash
-claude plugin marketplace add /tmp/mindthus-release/claude-code
+claude plugin marketplace add /tmp/mindthus-plugins/claude-code
 claude plugin install mindthus@mindthus
 claude plugin list
 ```
@@ -160,12 +173,12 @@ claude plugin marketplace remove mindthus
 
 ### Codex Skills-Pack Mode
 
-release pack 里也包含 Codex skills-pack 形态。这个方式适合不能使用插件管理、需要 portable checkout，或想保留 `mindthus:*` skills namespace 的环境。
+skills release pack 里包含 Codex skills-pack 形态。这个方式适合不能使用插件管理、需要 portable checkout，或想保留 `mindthus:*` skills namespace 的环境。
 
 ```bash
 rm -rf "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
 mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
-cp -R /tmp/mindthus-release/codex/skills/mindthus "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
+cp -R /tmp/mindthus-skills/codex/skills/mindthus "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
 ```
 
 重启 Codex 后，可以通过 `mindthus:*` 命名空间使用这些 skills，例如 `mindthus:tplan`。
@@ -189,7 +202,7 @@ rm -rf "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
 
 ```bash
 mkdir -p ~/.claude/skills
-for skill in /tmp/mindthus-release/claude-code/claude-plugin/skills/*; do
+for skill in /tmp/mindthus-skills/claude-code/skills/*; do
   [ -f "$skill/SKILL.md" ] || continue
   rm -rf "$HOME/.claude/skills/$(basename "$skill")"
   cp -R "$skill" "$HOME/.claude/skills/"
@@ -216,7 +229,7 @@ rm -rf ~/.claude/skills/{3l5s,edsp,mpg,sela,tplan,tvg,using-mindthus,wae}
 OpenCode 继续使用 skills-pack mode：生成包中的 `opencode/.opencode/skills/mindthus/<skill>/SKILL.md` 是当前支持路径。
 
 ```bash
-cp -R /tmp/mindthus-release/opencode/.opencode /path/to/your/opencode-project/
+cp -R /tmp/mindthus-skills/opencode/.opencode /path/to/your/opencode-project/
 ```
 
 OpenCode 虽然有 plugin system，但 v1.2 不提供 OpenCode plugin mode，因为当前 OpenCode plugin API 尚未验证能原生贡献 `SKILL.md` skills。Mindthus 不用 hook、command 或 custom tool 模拟 native skills。

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -19,21 +19,28 @@ plugin packaging is the product shell.
 
 ## 安装入口
 
-普通用户先下载 release asset：
+普通用户按用途下载 release asset。plugin mode 下载 plugins 包；skills-pack mode 下载 skills 包：
 
 ```bash
 VERSION=1.2.0
 curl -L \
-  -o /tmp/mindthus-release-${VERSION}.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-release-${VERSION}.tar.gz"
-rm -rf /tmp/mindthus-release
-mkdir -p /tmp/mindthus-release
-tar -xzf /tmp/mindthus-release-${VERSION}.tar.gz -C /tmp/mindthus-release --strip-components=1
+  -o /tmp/mindthus-plugins-${VERSION}.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-plugins-${VERSION}.tar.gz"
+rm -rf /tmp/mindthus-plugins
+mkdir -p /tmp/mindthus-plugins
+tar -xzf /tmp/mindthus-plugins-${VERSION}.tar.gz -C /tmp/mindthus-plugins --strip-components=1
+
+curl -L \
+  -o /tmp/mindthus-skills-${VERSION}.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-skills-${VERSION}.tar.gz"
+rm -rf /tmp/mindthus-skills
+mkdir -p /tmp/mindthus-skills
+tar -xzf /tmp/mindthus-skills-${VERSION}.tar.gz -C /tmp/mindthus-skills --strip-components=1
 ```
 
-本次 release asset 名称是 `mindthus-release-1.2.0.tar.gz`。
+本次 release asset 名称是 `mindthus-plugins-1.2.0.tar.gz` 和 `mindthus-skills-1.2.0.tar.gz`。
 
-解压后，Codex plugin、Claude Code plugin、Codex skills-pack、Claude personal skills 和 OpenCode skills-pack 都从 `/tmp/mindthus-release` 安装。
+解压后，Codex plugin 和 Claude Code plugin 从 `/tmp/mindthus-plugins` 安装；Codex skills-pack、Claude personal skills 和 OpenCode skills-pack 从 `/tmp/mindthus-skills` 安装。
 
 ## 新增
 
@@ -63,7 +70,7 @@ codex-plugin/.agents/plugins/marketplace.json
 因此可以直接运行：
 
 ```bash
-codex plugin marketplace add /tmp/mindthus-release/codex-plugin
+codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin
 codex plugin add mindthus@mindthus
 ```
 
@@ -119,7 +126,9 @@ Packaging tests 现在覆盖：
 - Codex plugin manifest version、`skills` 指向和 router-only default prompt；
 - Codex plugin marketplace manifest，使 `codex plugin marketplace add <release>/codex-plugin` 可以直接发现 `mindthus@mindthus`；
 - Codex plugin artifact 的 public docs、scripts、licenses 和 skill frontmatter；
+- release assets 分成 `mindthus-plugins-1.2.0.tar.gz` 和 `mindthus-skills-1.2.0.tar.gz`，多平台合包，但 plugin mode 和 skills-pack mode 分离；
 - release pack 仍排除 `docs/internal/`、`docs/superpowers/`、tests、logs、runtime files 和临时产物；
+- release pack 不携带 methodology 文档图片等二进制大图资产；图文阅读入口保留在 GitHub 仓库和官网文档；
 - `opencode-plugin/` 缺省不生成。
 
 ## 边界
@@ -137,15 +146,16 @@ Packaging tests 现在覆盖：
 ```bash
 python3 -m unittest tests.test_packaging_docs -v
 python3 -m unittest discover -s tests -v
-python3 scripts/build-release-pack.py --out /tmp/mindthus-release --force
+python3 scripts/build-release-pack.py --package plugins --out /tmp/mindthus-plugins --force
+python3 scripts/build-release-pack.py --package skills --out /tmp/mindthus-skills --force
 ```
 
 本机插件 smoke test 通过：
 
 ```bash
-claude plugin validate /tmp/mindthus-release/claude-code/claude-plugin --strict
-claude plugin validate /tmp/mindthus-release/claude-code --strict
-claude plugin marketplace add /tmp/mindthus-release/claude-code
+claude plugin validate /tmp/mindthus-plugins/claude-code/claude-plugin --strict
+claude plugin validate /tmp/mindthus-plugins/claude-code --strict
+claude plugin marketplace add /tmp/mindthus-plugins/claude-code
 claude plugin install mindthus@mindthus
 codex plugin marketplace add <temporary-marketplace> --json
 codex plugin list --marketplace mindthus-smoke --available --json
@@ -160,4 +170,4 @@ codex plugin add mindthus@mindthus-smoke --json
 - generated Codex plugin cache does not contain `skills/_runtime`;
 - generated Codex plugin cache contains plugin-root `_runtime/fidelity/core.py`;
 - generated release pack does not contain `opencode-plugin/`.
-- release asset packaged as `mindthus-release-1.2.0.tar.gz`.
+- release assets packaged as `mindthus-plugins-1.2.0.tar.gz` and `mindthus-skills-1.2.0.tar.gz`.

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -21,10 +21,6 @@ EXCLUDED_DIRS = {
     "tests",
 }
 EXCLUDED_SUFFIXES = {".gif", ".jpeg", ".jpg", ".log", ".mov", ".mp4", ".png", ".pyc", ".pyo", ".tmp", ".webp"}
-METHODOLOGY_BINARY_ASSET_ALLOWLIST = {
-    Path("assets/tplan-okr-runtime.png"),
-    Path("assets/tvg-architecture.png"),
-}
 EXCLUDED_NAME_SUBSTRINGS = ("ab_run", "pilot")
 JSONL_ALLOWLIST = {Path("tplan/templates/evidence.jsonl")}
 TEXT_REWRITE_SUFFIXES = {".md"}
@@ -163,13 +159,17 @@ def build_claude_code(root: Path, repo: Path, skills_dir: Path, methodologies_di
         },
     )
     copy_tree_filtered(skills_dir, plugin_root / "skills")
-    copy_tree_filtered(
-        methodologies_dir,
-        plugin_root / "docs" / "methodologies",
-        binary_asset_allowlist=METHODOLOGY_BINARY_ASSET_ALLOWLIST,
-    )
+    copy_tree_filtered(methodologies_dir, plugin_root / "docs" / "methodologies")
     copy_license_files(repo, plugin_root)
     copy_release_scripts(repo, plugin_root)
+
+
+def build_claude_code_skills(root: Path, repo: Path, skills_dir: Path, methodologies_dir: Path) -> None:
+    platform_root = root / "claude-code"
+    copy_tree_filtered(skills_dir, platform_root / "skills")
+    copy_tree_filtered(methodologies_dir, platform_root / "docs" / "methodologies")
+    copy_license_files(repo, platform_root)
+    copy_release_scripts(repo, platform_root)
 
 
 def build_codex(root: Path, repo: Path, skills_dir: Path, agents_file: Path, methodologies_dir: Path) -> None:
@@ -180,7 +180,6 @@ def build_codex(root: Path, repo: Path, skills_dir: Path, agents_file: Path, met
         methodologies_dir,
         platform_root / "docs" / "methodologies",
         replacements,
-        binary_asset_allowlist=METHODOLOGY_BINARY_ASSET_ALLOWLIST,
     )
     copy_file_filtered(agents_file, platform_root / "AGENTS.md", replacements)
     copy_license_files(repo, platform_root)
@@ -250,7 +249,6 @@ def build_codex_plugin(root: Path, repo: Path, skills_dir: Path, methodologies_d
     copy_tree_filtered(
         methodologies_dir,
         plugin_root / "docs" / "methodologies",
-        binary_asset_allowlist=METHODOLOGY_BINARY_ASSET_ALLOWLIST,
     )
     copy_license_files(repo, plugin_root)
     copy_release_scripts(repo, plugin_root)
@@ -264,7 +262,6 @@ def build_opencode(root: Path, repo: Path, skills_dir: Path, agents_file: Path, 
         methodologies_dir,
         platform_root / "docs" / "methodologies",
         replacements,
-        binary_asset_allowlist=METHODOLOGY_BINARY_ASSET_ALLOWLIST,
     )
     copy_file_filtered(agents_file, platform_root / "AGENTS.md", replacements)
     copy_license_files(repo, platform_root)
@@ -274,6 +271,12 @@ def build_opencode(root: Path, repo: Path, skills_dir: Path, agents_file: Path, 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out", required=True, type=Path, help="Output directory for the release pack.")
+    parser.add_argument(
+        "--package",
+        choices=("all", "plugins", "skills"),
+        default="all",
+        help="Package surface to build. Release assets use plugins and skills; all is for local inspection.",
+    )
     parser.add_argument("--force", action="store_true", help="Replace a non-empty output directory.")
     args = parser.parse_args()
 
@@ -297,11 +300,14 @@ def main() -> int:
     output = args.out.resolve()
     ensure_safe_output_dir(output, root)
     ensure_output_dir(output, args.force)
-    build_claude_code(output, root, skills_dir, methodologies_dir)
-    build_codex(output, root, skills_dir, agents_file, methodologies_dir)
-    build_codex_plugin(output, root, skills_dir, methodologies_dir)
-    build_opencode(output, root, skills_dir, agents_file, methodologies_dir)
-    print(f"built Mindthus release pack at {output}")
+    if args.package in ("all", "plugins"):
+        build_claude_code(output, root, skills_dir, methodologies_dir)
+        build_codex_plugin(output, root, skills_dir, methodologies_dir)
+    if args.package in ("all", "skills"):
+        build_claude_code_skills(output, root, skills_dir, methodologies_dir)
+        build_codex(output, root, skills_dir, agents_file, methodologies_dir)
+        build_opencode(output, root, skills_dir, agents_file, methodologies_dir)
+    print(f"built Mindthus {args.package} release pack at {output}")
     return 0
 
 

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -402,20 +402,11 @@ class PackagingDocsTests(unittest.TestCase):
             ".webp",
         }
         jsonl_allowlist = {
+            Path("claude-code/skills/tplan/templates/evidence.jsonl"),
             Path("claude-code/claude-plugin/skills/tplan/templates/evidence.jsonl"),
             Path("codex/skills/mindthus/tplan/templates/evidence.jsonl"),
             Path("codex-plugin/mindthus/skills/tplan/templates/evidence.jsonl"),
             Path("opencode/.opencode/skills/mindthus/tplan/templates/evidence.jsonl"),
-        }
-        binary_asset_allowlist = {
-            Path("claude-code/claude-plugin/docs/methodologies/assets/tplan-okr-runtime.png"),
-            Path("claude-code/claude-plugin/docs/methodologies/assets/tvg-architecture.png"),
-            Path("codex/docs/methodologies/assets/tplan-okr-runtime.png"),
-            Path("codex/docs/methodologies/assets/tvg-architecture.png"),
-            Path("codex-plugin/mindthus/docs/methodologies/assets/tplan-okr-runtime.png"),
-            Path("codex-plugin/mindthus/docs/methodologies/assets/tvg-architecture.png"),
-            Path("opencode/docs/methodologies/assets/tplan-okr-runtime.png"),
-            Path("opencode/docs/methodologies/assets/tvg-architecture.png"),
         }
         jsonl_paths: set[Path] = set()
         binary_asset_paths: set[Path] = set()
@@ -428,11 +419,6 @@ class PackagingDocsTests(unittest.TestCase):
             )
             if path.is_file():
                 if path.suffix in forbidden_suffixes:
-                    self.assertIn(
-                        rel,
-                        binary_asset_allowlist,
-                        f"release pack should not include runtime artifact file: {rel}",
-                    )
                     binary_asset_paths.add(rel)
                 lowered = rel.as_posix().lower()
                 self.assertNotIn("ab_run", lowered)
@@ -440,8 +426,11 @@ class PackagingDocsTests(unittest.TestCase):
                 if path.suffix == ".jsonl":
                     jsonl_paths.add(rel)
 
-        self.assertEqual(jsonl_paths, jsonl_allowlist)
-        self.assertEqual(binary_asset_paths, binary_asset_allowlist)
+        self.assertTrue(
+            jsonl_paths.issubset(jsonl_allowlist),
+            f"release pack should only include allowlisted jsonl templates: {jsonl_paths - jsonl_allowlist}",
+        )
+        self.assertEqual(binary_asset_paths, set(), "release packs should not carry binary images or media")
 
     def test_skill_frontmatter_parser_rejects_unquoted_nested_colon(self):
         with self.assertRaises(ValueError):
@@ -473,10 +462,10 @@ class PackagingDocsTests(unittest.TestCase):
 
         self.assertIn("plugin mode", readme)
         self.assertIn("Codex Plugin Mode（推荐）", readme)
-        self.assertIn("codex plugin marketplace add /tmp/mindthus-release/codex-plugin", readme)
+        self.assertIn("codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin", readme)
         self.assertIn("codex plugin add mindthus@mindthus", readme)
         self.assertIn("Claude Code Plugin Mode（推荐）", readme)
-        self.assertIn("claude plugin marketplace add /tmp/mindthus-release/claude-code", readme)
+        self.assertIn("claude plugin marketplace add /tmp/mindthus-plugins/claude-code", readme)
         self.assertIn("claude plugin install mindthus@mindthus", readme)
         self.assertIn("Codex Skills-Pack Mode", readme)
         self.assertIn("Claude Code Personal Skills Mode", readme)
@@ -580,6 +569,9 @@ class PackagingDocsTests(unittest.TestCase):
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "mpg" / "SKILL.md").exists())
             for path in sorted((out / "claude-code" / "claude-plugin" / "skills").glob("*/SKILL.md")):
                 self.assert_skill_frontmatter_is_parseable(path)
+            self.assertTrue((out / "claude-code" / "skills" / "tplan" / "SKILL.md").exists())
+            self.assertTrue((out / "claude-code" / "skills" / "mpg" / "SKILL.md").exists())
+            self.assertTrue((out / "claude-code" / "docs" / "methodologies" / "shared-primitives.md").exists())
             self.assertTrue(
                 (out / "claude-code" / "claude-plugin" / "scripts" / "run-fidelity-judge.py").exists()
             )
@@ -692,6 +684,42 @@ class PackagingDocsTests(unittest.TestCase):
                 )
                 for skill_name in skill_names:
                     self.assertNotIn(f"skills/{skill_name}/", markdown)
+
+    def test_release_pack_builder_can_split_plugin_and_skills_packages(self):
+        script = REPO / "scripts" / "build-release-pack.py"
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            plugins = tmp_dir / "mindthus-plugins-1.2.0"
+            skills = tmp_dir / "mindthus-skills-1.2.0"
+
+            plugin_result = subprocess.run(
+                ["python3", str(script), "--package", "plugins", "--out", str(plugins)],
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(plugin_result.returncode, 0, plugin_result.stderr)
+            self.assert_release_pack_excludes_runtime_artifacts(plugins)
+            self.assertTrue((plugins / "codex-plugin" / "mindthus" / ".codex-plugin" / "plugin.json").exists())
+            self.assertTrue((plugins / "claude-code" / ".claude-plugin" / "marketplace.json").exists())
+            self.assertFalse((plugins / "codex").exists())
+            self.assertFalse((plugins / "opencode").exists())
+            self.assertFalse((plugins / "claude-code" / "skills").exists())
+
+            skills_result = subprocess.run(
+                ["python3", str(script), "--package", "skills", "--out", str(skills)],
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(skills_result.returncode, 0, skills_result.stderr)
+            self.assert_release_pack_excludes_runtime_artifacts(skills)
+            self.assertTrue((skills / "codex" / "skills" / "mindthus" / "tplan" / "SKILL.md").exists())
+            self.assertTrue((skills / "claude-code" / "skills" / "tplan" / "SKILL.md").exists())
+            self.assertTrue(
+                (skills / "opencode" / ".opencode" / "skills" / "mindthus" / "tplan" / "SKILL.md").exists()
+            )
+            self.assertFalse((skills / "codex-plugin").exists())
+            self.assertFalse((skills / "claude-code" / ".claude-plugin").exists())
+            self.assertFalse((skills / "claude-code" / "claude-plugin").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -17,12 +17,14 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         self.assertNotIn("## 版本与开发状态", readme)
         self.assertNotIn("当前开发分支同步", readme)
         self.assertIn("VERSION=1.2.0", readme)
-        self.assertIn("mindthus-release-${VERSION}.tar.gz", readme)
-        self.assertIn("mindthus-release-1.2.0.tar.gz", readme)
+        self.assertIn("mindthus-plugins-${VERSION}.tar.gz", readme)
+        self.assertIn("mindthus-skills-${VERSION}.tar.gz", readme)
+        self.assertIn("mindthus-plugins-1.2.0.tar.gz", readme)
+        self.assertIn("mindthus-skills-1.2.0.tar.gz", readme)
         self.assertIn("github.com/rv198-star/Mindthus/releases/download/v${VERSION}", readme)
-        self.assertIn("codex plugin marketplace add /tmp/mindthus-release/codex-plugin", readme)
-        self.assertIn("claude plugin marketplace add /tmp/mindthus-release/claude-code", readme)
-        self.assertIn("cp -R /tmp/mindthus-release/opencode/.opencode", readme)
+        self.assertIn("codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin", readme)
+        self.assertIn("claude plugin marketplace add /tmp/mindthus-plugins/claude-code", readme)
+        self.assertIn("cp -R /tmp/mindthus-skills/opencode/.opencode", readme)
         self.assertIn("## v1.2.0", changelog)
         self.assertIn("[完整发布日志](docs/releases/v1.2.0.md)", changelog)
         self.assertIn("release-pack-first", changelog)
@@ -35,7 +37,8 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
             "# Mindthus v1.2.0 发布日志",
             "发布日期：2026-06-24",
             "release pack",
-            "mindthus-release-1.2.0.tar.gz",
+            "mindthus-plugins-1.2.0.tar.gz",
+            "mindthus-skills-1.2.0.tar.gz",
             "codex-plugin/.agents/plugins/marketplace.json",
             "codex plugin add mindthus@mindthus",
             "claude plugin install mindthus@mindthus",


### PR DESCRIPTION
## Summary
- split v1.2.0 release packaging into plugins and skills package surfaces
- stop carrying methodology binary image assets in release packs
- update README, changelog, release notes, and packaging contract tests

## Verification
- python3 -m unittest tests.test_packaging_docs tests.test_release_boundary_contract -v
- python3 -m unittest discover -s tests -v
- python3 scripts/build-release-pack.py --package plugins --out /tmp/mindthus-plugins --force
- python3 scripts/build-release-pack.py --package skills --out /tmp/mindthus-skills --force
- Codex plugin validator passed for /tmp/mindthus-plugins/codex-plugin/mindthus
- Claude Code strict validation passed for /tmp/mindthus-plugins/claude-code and /tmp/mindthus-plugins/claude-code/claude-plugin
- Codex and Claude temporary marketplace/install smoke passed

Package sizes:
- /tmp/mindthus-plugins-1.2.0.tar.gz: 463K
- /tmp/mindthus-skills-1.2.0.tar.gz: 704K