### PR TITLE
docs: clarify release package selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,29 +85,38 @@ Mindthus 适合放进真实 agent 工作流，尤其是这些场景：
 
 ## 安装
 
-Mindthus 有两种安装形态，推荐顺序很简单：
+### 选择下载包
 
-- **推荐：plugin mode**。Codex App 和 Claude Code 优先用这个方式，把 Mindthus 当作一个插件产品启用、更新和禁用。
-- **备选：skills-pack mode**。适合开发调试、portable checkout、不能使用插件管理的环境，以及 OpenCode。
+| 你的场景 | 下载哪个包 | 安装后得到什么 | 推荐度 |
+| --- | --- | --- | --- |
+| Codex App，想用插件管理启用/更新/卸载 | `mindthus-plugins-${VERSION}.tar.gz` | Codex plugin marketplace + `mindthus@mindthus` plugin | 推荐 |
+| Claude Code，想用插件命名空间 | `mindthus-plugins-${VERSION}.tar.gz` | Claude Code marketplace + `/mindthus:<skill>` | 推荐 |
+| Codex skills-pack | `mindthus-skills-${VERSION}.tar.gz` | `~/.codex/skills/mindthus` 下的 `mindthus:*` skills | 备选 |
+| Claude Code personal skills | `mindthus-skills-${VERSION}.tar.gz` | `~/.claude/skills/<skill>` 下的 personal skills | 备选 |
+| OpenCode | `mindthus-skills-${VERSION}.tar.gz` | 项目内 `.opencode/skills/mindthus/<skill>` | 当前支持方式 |
 
-同一个 client profile 里不要同时启用 plugin mode 和 skills-pack mode，除非你明确想测试重复 discovery。迁移到 plugin mode 前，先移除旧的 skills-pack symlink。
+不要在同一个 client profile 里同时安装 plugin mode 和 skills-pack mode，除非你正在测试重复 discovery。
 
-普通用户不需要 clone 仓库。优先按用途下载 release pack：
-
-- plugin mode：下载 `mindthus-plugins-${VERSION}.tar.gz`，包含 Codex plugin 和 Claude Code plugin。
-- skills-pack mode：下载 `mindthus-skills-${VERSION}.tar.gz`，包含 Codex、Claude Code personal skills 和 OpenCode 的 skills-pack 布局。
-
-release pack 不携带 methodology 文档里的大图资产；需要看图文版文档时，直接读 GitHub 仓库或官网文档。
+### 下载
 
 ```bash
 VERSION=1.2.0
+```
+
+插件包，供 Codex App / Claude Code plugin mode 使用：
+
+```bash
 curl -L \
   -o /tmp/mindthus-plugins-${VERSION}.tar.gz \
   "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-plugins-${VERSION}.tar.gz"
 rm -rf /tmp/mindthus-plugins
 mkdir -p /tmp/mindthus-plugins
 tar -xzf /tmp/mindthus-plugins-${VERSION}.tar.gz -C /tmp/mindthus-plugins --strip-components=1
+```
 
+Skills 包，供 Codex skills-pack / Claude Code personal skills / OpenCode 使用：
+
+```bash
 curl -L \
   -o /tmp/mindthus-skills-${VERSION}.tar.gz \
   "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-skills-${VERSION}.tar.gz"
@@ -116,20 +125,7 @@ mkdir -p /tmp/mindthus-skills
 tar -xzf /tmp/mindthus-skills-${VERSION}.tar.gz -C /tmp/mindthus-skills --strip-components=1
 ```
 
-当前 release asset 名称是 `mindthus-plugins-1.2.0.tar.gz` 和 `mindthus-skills-1.2.0.tar.gz`。
-
-如果你正在开发 Mindthus，才需要从源码构建同样结构的 release pack：
-
-```bash
-git clone https://github.com/rv198-star/Mindthus.git ~/mindthus
-cd ~/mindthus
-python3 scripts/build-release-pack.py --package plugins --out /tmp/mindthus-plugins --force
-python3 scripts/build-release-pack.py --package skills --out /tmp/mindthus-skills --force
-```
-
 ### Codex Plugin Mode（推荐）
-
-Codex plugin mode 使用 plugins release pack 里的 `codex-plugin/` marketplace。安装后，Codex 通过插件管理 Mindthus，并读取插件内同源的 `skills/`。
 
 ```bash
 codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin
@@ -138,7 +134,7 @@ codex plugin add mindthus@mindthus
 codex plugin list
 ```
 
-重启 Codex App 后即可使用。插件 metadata 只注入一句轻量 router-only 纪律：当问题涉及战略判断、结构歧义、路径波动、控制边界、产物价值厚度时，优先使用 `using-mindthus` 选择最小充分方法；清楚低风险任务直接执行。
+重启 Codex App 后使用。可直接提到 `mindthus:tplan`、`using-mindthus` 等 skill 名称。
 
 卸载：
 
@@ -149,20 +145,13 @@ codex plugin marketplace remove mindthus
 
 ### Claude Code Plugin Mode（推荐）
 
-Claude Code plugin mode 使用 plugins release pack 里的 `claude-code/` marketplace。安装后，skills 带插件命名空间，例如 `/mindthus:using-mindthus`。
-
 ```bash
 claude plugin marketplace add /tmp/mindthus-plugins/claude-code
 claude plugin install mindthus@mindthus
 claude plugin list
 ```
 
-重启 Claude Code 后即可使用。更新时重新构建 release pack，然后运行：
-
-```bash
-claude plugin marketplace update mindthus
-claude plugin update mindthus
-```
+重启 Claude Code 后使用。调用 `/mindthus:using-mindthus`、`/mindthus:tplan` 等插件命名空间 skills。
 
 卸载：
 
@@ -173,30 +162,19 @@ claude plugin marketplace remove mindthus
 
 ### Codex Skills-Pack Mode
 
-skills release pack 里包含 Codex skills-pack 形态。这个方式适合不能使用插件管理、需要 portable checkout，或想保留 `mindthus:*` skills namespace 的环境。
-
 ```bash
 rm -rf "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
 mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
 cp -R /tmp/mindthus-skills/codex/skills/mindthus "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
 ```
 
-重启 Codex 后，可以通过 `mindthus:*` 命名空间使用这些 skills，例如 `mindthus:tplan`。
-
-如果你是开发者，并希望 skills 直接跟随当前 checkout，可以改用 symlink installer：
-
-```bash
-cd ~/mindthus
-scripts/install-skills.sh codex --force
-```
+重启 Codex 后使用 `mindthus:*` skills，例如 `mindthus:tplan`。
 
 卸载：
 
 ```bash
 rm -rf "${CODEX_HOME:-$HOME/.codex}/skills/mindthus"
 ```
-
-详细说明见 [.codex/INSTALL.md](.codex/INSTALL.md)。
 
 ### Claude Code Personal Skills Mode
 
@@ -209,14 +187,7 @@ for skill in /tmp/mindthus-skills/claude-code/skills/*; do
 done
 ```
 
-这会把同一套 `skills/` 安装到 Claude Code personal skills 路径。personal skills mode 不会增加 `mindthus:` plugin namespace，通常暴露为 `/<skill>`，或由 Claude 根据 skill description 自动调用。
-
-开发者也可以用 checkout symlink installer：
-
-```bash
-cd ~/mindthus
-scripts/install-skills.sh claude --force
-```
+重启 Claude Code 后使用 `/<skill>`，例如 `/tplan`；personal skills mode 不会增加 `mindthus:` plugin namespace。
 
 卸载：
 
@@ -226,13 +197,11 @@ rm -rf ~/.claude/skills/{3l5s,edsp,mpg,sela,tplan,tvg,using-mindthus,wae}
 
 ### OpenCode
 
-OpenCode 继续使用 skills-pack mode：生成包中的 `opencode/.opencode/skills/mindthus/<skill>/SKILL.md` 是当前支持路径。
-
 ```bash
 cp -R /tmp/mindthus-skills/opencode/.opencode /path/to/your/opencode-project/
 ```
 
-OpenCode 虽然有 plugin system，但 v1.2 不提供 OpenCode plugin mode，因为当前 OpenCode plugin API 尚未验证能原生贡献 `SKILL.md` skills。Mindthus 不用 hook、command 或 custom tool 模拟 native skills。
+在该 OpenCode project 中使用 `.opencode/skills/mindthus/<skill>`。
 
 ## 验证
 

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -461,18 +461,26 @@ class PackagingDocsTests(unittest.TestCase):
         self.assertIn("清楚低风险任务直接执行", install)
 
         self.assertIn("plugin mode", readme)
+        self.assertIn("### 选择下载包", readme)
+        self.assertIn("Codex App，想用插件管理启用/更新/卸载", readme)
+        self.assertIn("Claude Code personal skills", readme)
+        self.assertIn("不要在同一个 client profile 里同时安装 plugin mode 和 skills-pack mode", readme)
+        self.assertIn("插件包，供 Codex App / Claude Code plugin mode 使用", readme)
+        self.assertIn("Skills 包，供 Codex skills-pack / Claude Code personal skills / OpenCode 使用", readme)
         self.assertIn("Codex Plugin Mode（推荐）", readme)
         self.assertIn("codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin", readme)
         self.assertIn("codex plugin add mindthus@mindthus", readme)
         self.assertIn("Claude Code Plugin Mode（推荐）", readme)
         self.assertIn("claude plugin marketplace add /tmp/mindthus-plugins/claude-code", readme)
         self.assertIn("claude plugin install mindthus@mindthus", readme)
+        self.assertIn("可直接提到 `mindthus:tplan`", readme)
+        self.assertIn("调用 `/mindthus:using-mindthus`", readme)
         self.assertIn("Codex Skills-Pack Mode", readme)
         self.assertIn("Claude Code Personal Skills Mode", readme)
         self.assertIn("/mindthus:using-mindthus", readme)
         self.assertIn("Claude Code", readme)
         self.assertIn("OpenCode", readme)
-        self.assertIn("OpenCode 继续使用 skills-pack", readme)
+        self.assertIn("在该 OpenCode project 中使用", readme)
 
     def test_install_script_exists_and_has_valid_shell_syntax(self):
         script = REPO / "scripts" / "install-skills.sh"

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -19,8 +19,6 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         self.assertIn("VERSION=1.2.0", readme)
         self.assertIn("mindthus-plugins-${VERSION}.tar.gz", readme)
         self.assertIn("mindthus-skills-${VERSION}.tar.gz", readme)
-        self.assertIn("mindthus-plugins-1.2.0.tar.gz", readme)
-        self.assertIn("mindthus-skills-1.2.0.tar.gz", readme)
         self.assertIn("github.com/rv198-star/Mindthus/releases/download/v${VERSION}", readme)
         self.assertIn("codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin", readme)
         self.assertIn("claude plugin marketplace add /tmp/mindthus-plugins/claude-code", readme)


### PR DESCRIPTION
## Summary
- replace the verbose install narrative with a direct package-selection table
- keep only download, install, use, and uninstall commands for each supported mode
- update packaging/release contract tests for the shorter README surface

## Verification
- python3 -m unittest tests.test_packaging_docs tests.test_release_boundary_contract -v