### PR TITLE
release: Mindthus v1.4.5

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # The tplan A/B simulator archives a pinned historical baseline commit.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## Unreleased
 
-### Product convergence after diagnostic research
+## v1.4.5
+
+发布日期：2026-07-13
+
+[完整发布日志](docs/releases/v1.4.5.md)
+
+说明：这是一次可靠性与产品合同 patch release。它不新增方法、不改变 Mindthus 的核心
+定位，也不把未通过的自动唤起研究包装成能力升级；主要变化是把诊断研究中可复用的部分
+收回到更轻、更明确、更容易安装和验证的正式产品面。
+
+### 产品收敛
 
 日期：2026-07-13
 
@@ -20,7 +30,34 @@ V5 certification campaign。
   triage 研究 runtime。
 - 旧诊断 issues 按“完成 / 部分交付 / 停止研究”重新归档；诊断完成不再被表述为问题已解决。
 
-### v1.4.4-diag diagnostic milestone
+### 高频入口与发布包
+
+- `using-mindthus/SKILL.md` 从 11,224 bytes / 1,094 words 收敛到 7,193 bytes /
+  900 words；高频 preload 只保留介入边界、定框审计、定义权裁决、方法路由、执行影响和
+  停止条件，详细语义改为 conditional resources。
+- Frame Fitness 明确为 `frame-risk AND execution impact` 才运行；触发后必须记录
+  `routing_decision`，避免既过度审计又丢失路由结果。
+- 七份条件原语文档被镜像进 Claude plugin、Claude skills、Codex plugin、Codex skills
+  和 OpenCode skills 五种发布布局；打包测试验证改写后的 fidelity 链接真实可达。
+- Codex plugin 增加正式图标与 logo；通用 timeout bytes 解码修复进入公开代码。
+
+### 评测与边界
+
+- 公共 50 场景 fixture、runner、双层误唤醒口径和历史 artifacts 保留为可复查证据，
+  但不进入 release pack，也不构成自动唤起认证。
+- V4 treatment positive mean 仍为 `1.447 < 1.5`；register-hints、semantic triage 和
+  后续 shadow 实验只作为诊断路线记录，未成为 v1.4.5 的生产承诺。
+- “SKILLS 本质是提示词”与 4K/5K 判断场景的有效改进保留在 Whole Elephant、Decision
+  Context、Definition Authority 和首句落锤合同中；不依赖题号 matcher。
+
+### 验证
+
+- `python3 -m unittest discover -s tests -p 'test_*.py' -q`
+- `python3 scripts/build-release-pack.py --package plugins --out /tmp/mindthus-release-plugins-check --force`
+- `python3 scripts/build-release-pack.py --package skills --out /tmp/mindthus-release-skills-check --force`
+- 五种发布布局的入口 SHA 与条件资源链接通过独立复核。
+
+## v1.4.4-diag diagnostic milestone
 
 日期：2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Host 根据自然语言自行发现并唤起 Mindthus 属于 **best-effort** 能
 
 优先安装插件包；插件不可用或需要 portable skills 时，再安装 skills 包。
 
-- Codex App / Codex CLI / Claude Code 支持插件：下载 `mindthus-plugins-1.4.3.tar.gz`。
-- 不使用插件、需要 OpenCode、或只想复制 skills 目录：下载 `mindthus-skills-1.4.3.tar.gz`。
+- Codex App / Codex CLI / Claude Code 支持插件：下载 `mindthus-plugins-1.4.5.tar.gz`。
+- 不使用插件、需要 OpenCode、或只想复制 skills 目录：下载 `mindthus-skills-1.4.5.tar.gz`。
 
 不要在同一个 client profile 里同时安装 plugin mode 和 skills-pack mode，除非你正在测试重复 discovery。
 
@@ -110,22 +110,22 @@ Host 根据自然语言自行发现并唤起 Mindthus 属于 **best-effort** 能
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-plugins-1.4.3.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.4.3/mindthus-plugins-1.4.3.tar.gz"
+  -o /tmp/mindthus-plugins-1.4.5.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.4.5/mindthus-plugins-1.4.5.tar.gz"
 rm -rf /tmp/mindthus-plugins
 mkdir -p /tmp/mindthus-plugins
-tar -xzf /tmp/mindthus-plugins-1.4.3.tar.gz -C /tmp/mindthus-plugins --strip-components=1
+tar -xzf /tmp/mindthus-plugins-1.4.5.tar.gz -C /tmp/mindthus-plugins --strip-components=1
 ```
 
 Skills 包，供 Codex skills-pack / Claude Code personal skills / OpenCode 使用：
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-skills-1.4.3.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.4.3/mindthus-skills-1.4.3.tar.gz"
+  -o /tmp/mindthus-skills-1.4.5.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.4.5/mindthus-skills-1.4.5.tar.gz"
 rm -rf /tmp/mindthus-skills
 mkdir -p /tmp/mindthus-skills
-tar -xzf /tmp/mindthus-skills-1.4.3.tar.gz -C /tmp/mindthus-skills --strip-components=1
+tar -xzf /tmp/mindthus-skills-1.4.5.tar.gz -C /tmp/mindthus-skills --strip-components=1
 ```
 
 ### Codex Plugin Mode（推荐）
@@ -249,7 +249,7 @@ python3 scripts/log-fidelity-usage.py --help
 
 ## 版本与许可
 
-当前仓库版本：`v1.4.3`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
+当前仓库版本：`v1.4.5`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
 
 Mindthus uses AGPLv3 + commercial dual licensing.
 

--- a/docs/releases/v1.4.5.md
+++ b/docs/releases/v1.4.5.md
@@ -1,0 +1,133 @@
+# Mindthus v1.4.5 发布日志
+
+发布日期：2026-07-13
+
+## 版本定位
+
+`v1.4.5` 是一次可靠性与产品合同 patch release。
+
+这轮改动很多，但没有新增主方法、改变核心概念或引入不兼容接口。它把一次较长的诊断
+研究收束成少量高置信成果，同时停止继续打磨收益很低的自动唤起 prompt / matcher 路线。
+
+对使用者最直接的变化是：
+
+- 显式调用 `using-mindthus` 或具体 skill 是可靠主路径；host 自动唤起是 best-effort。
+- 高频入口更短，详细规则按需读取，减少每次唤起的上下文负担。
+- “局部正确接管全局判断”与“各打五十大板”继续由可见的定义权裁决和决策语境校准处理。
+- 发布包在 Codex、Claude Code 和 OpenCode 的五种布局中携带相同的条件资源。
+
+## 主要变化
+
+### 更清楚的产品使用合同
+
+README 现在明确区分两条路径：
+
+1. 显式调用：用户或 agent 明确读取 `using-mindthus` / 具体 Mindthus skill，这是可依赖主路径。
+2. 自动发现：由 host 根据描述决定是否加载，只能视为 best-effort，不能成为正确性保证。
+
+这能避免把不同宿主的 discovery 行为误认为 Mindthus 自己已经解决了自然唤起。
+
+### 更轻的 using-mindthus 入口
+
+`skills/using-mindthus/SKILL.md` 从 11,224 bytes / 1,094 words 收敛到
+7,193 bytes / 900 words。
+
+preload 面只保留：
+
+- 直接执行 / 先补事实 / Mindthus 介入边界；
+- Input Framing Audit；
+- Partial Truth、Whole Elephant 与 Definition Authority；
+- 七个方法 owner 的最小路由条件；
+- Execution Impact、Method Arbitration 与 Anti-Spiral；
+- 条件资源和 validator 的读取入口。
+
+详细规则没有删除，而是进入 conditional resources。Frame Fitness 的触发条件也被明确为
+`frame-risk AND execution impact`；触发后必须记录 `routing_decision`。
+
+### 两个真实判断场景的保留改进
+
+- “SKILLS 本质是提示词”：先锁定完整对象与结果主控，再承认 prompt 是局部承载，避免把
+  实现介质升级为能力上限或定义本体。
+- 4K/5K 显示器争论：先锁定当前购买者、目标函数和时点，再决定哪个框架拥有本次决策的
+  定义权，避免用“双方都对”代替判断。
+
+这些改进保留在 Whole Elephant、Decision Context、Definition Authority 和首句落锤合同
+中，不依赖公开题号或题面 matcher。
+
+### 公共方法与 runtime 分离
+
+#101 的公共方法文档与运行时合同已经分开：
+
+- `docs/methodologies/` 解释方法、适用边界和语义效果；
+- `skills/*` 承担 direct-load、validator、fallback、trace 和输出形状义务。
+
+release pack 同时保留必要的公开方法文档与 runtime 文件，但不会把内部研究文档和运行
+artifacts 混入安装包。
+
+### 发布包完整性
+
+- 七份 `using-mindthus` 条件原语被镜像到 Claude plugin、Claude skills、Codex plugin、
+  Codex skills 和 OpenCode skills。
+- 包内 Whole Elephant fidelity 链接改写为可移植相对路径，并由测试验证目标真实存在。
+- Codex plugin 带正式 icon / logo。
+- 通用 timeout 输出兼容 bytes，避免异常路径再次抛出解码错误。
+- 新增 10-20 个真实任务的轻量记录入口，用正常工作验证判断价值与额外负担。
+
+## 评测证据与边界
+
+公开 50 场景研究提供了有价值的测量基础，但没有得到自动唤起认证：
+
+- V4 treatment positive mean 为 `1.447 < 1.5`。
+- `v1.4.4-diag` 是诊断 tag，不是正式发布，也没有 release assets。
+- register-hints 证明显式 host hint 能加载目标 owner，但它不是自然唤起证据。
+- semantic triage、阈值和 matcher 路线没有通过独立 shadow 验收，不进入 v1.4.5 产品承诺。
+- 公开 fixture、runner 和历史 artifacts 留在仓库供复查，不进入 release pack。
+
+因此，v1.4.5 的声明是“入口与产品合同更可靠”，不是“Mindthus 已科学证明在所有宿主上
+自动唤起”。
+
+## 安装
+
+plugin mode 适用于 Codex App / CLI 与 Claude Code：
+
+```bash
+VERSION=1.4.5
+curl -L \
+  -o /tmp/mindthus-plugins-${VERSION}.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-plugins-${VERSION}.tar.gz"
+```
+
+skills-pack mode 适用于 OpenCode 或手动复制 skills：
+
+```bash
+VERSION=1.4.5
+curl -L \
+  -o /tmp/mindthus-skills-${VERSION}.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-skills-${VERSION}.tar.gz"
+```
+
+完整安装命令见 [README](../../README.md)。最终上传的 Release 资产同时提供
+`SHA256SUMS`；它在两个 tarball 生成后单独计算，不是 release-pack builder 的目录输出。
+
+## 升级影响
+
+- 无 schema migration。
+- 无新增必选依赖。
+- 已安装用户可直接用 v1.4.5 覆盖旧 plugin / skills 包。
+- 依赖自动 discovery 的工作流应继续把它视为 best-effort；关键判断请显式调用。
+
+## 验证
+
+```bash
+python3 -m unittest discover -s tests -p 'test_*.py' -q
+python3 scripts/build-release-pack.py --package plugins --out /tmp/mindthus-release-plugins-check --force
+python3 scripts/build-release-pack.py --package skills --out /tmp/mindthus-release-skills-check --force
+```
+
+发布前还会核对：
+
+- plugin release pack 内的 Codex / Claude 两份 plugin manifest 均为 `1.4.5`，
+  两类 release pack 内复制的 runtime logger 版本也均为 `1.4.5`；
+- 五种布局包含可解析的 skill frontmatter 和条件资源；
+- release pack 不含 tests、logs、内部研究文档或 benchmark 运行产物；
+- 构建资产的 SHA-256 与 GitHub Release 上传后下载结果一致。

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -9,7 +9,7 @@ import shutil
 from pathlib import Path
 
 
-VERSION = "1.4.3"
+VERSION = "1.4.5"
 EXCLUDED_DIRS = {
     "__pycache__",
     ".pytest_cache",

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -39,6 +39,15 @@ RELEASE_SCRIPT_PATHS = (
     Path("primitives/whole_elephant_validator.py"),
     Path("primitives/manifest.json"),
 )
+USING_MINDTHUS_CONDITIONAL_PRIMITIVES = (
+    "frame-fitness-check.md",
+    "entry-triage.md",
+    "aspect-ownership.md",
+    "decision-context-calibration.md",
+    "whole-elephant-protocol.md",
+    "expression-pressure-and-gates.md",
+    "mpg-scalar-commitment-unpack.md",
+)
 CLAUDE_ACTIVATION_ROUTER_PROMPT = (
     "遇事不要慌，先搞清楚情况再说。This is a light Mindthus activation router, not a mandatory workflow. "
     "Use mindthus:using-mindthus only at hard judgment points: problem definition, structural ambiguity, "
@@ -153,6 +162,25 @@ def copy_release_scripts(root: Path, target: Path) -> None:
         copy_file_filtered(root / "scripts" / rel_path, target / "scripts" / rel_path)
 
 
+def copy_using_mindthus_conditional_primitives(
+    methodologies_dir: Path,
+    skill_dir: Path,
+    replacements: dict[str, str] | None = None,
+) -> None:
+    resource_replacements = {
+        "../../../skills/using-mindthus/resources/fidelity-contract.md": "../fidelity-contract.md",
+        **(replacements or {}),
+    }
+    source_dir = methodologies_dir / "primitives"
+    target_dir = skill_dir / "resources" / "primitives"
+    for filename in USING_MINDTHUS_CONDITIONAL_PRIMITIVES:
+        copy_file_filtered(
+            source_dir / filename,
+            target_dir / filename,
+            resource_replacements,
+        )
+
+
 def write_claude_activation_hook(plugin_root: Path) -> None:
     write_json(
         plugin_root / "hooks" / "hooks.json",
@@ -226,6 +254,10 @@ def build_claude_code(root: Path, repo: Path, skills_dir: Path, methodologies_di
         },
     )
     copy_tree_filtered(skills_dir, plugin_root / "skills")
+    copy_using_mindthus_conditional_primitives(
+        methodologies_dir,
+        plugin_root / "skills" / "using-mindthus",
+    )
     copy_tree_filtered(methodologies_dir, plugin_root / "docs" / "methodologies")
     copy_license_files(repo, plugin_root)
     copy_release_scripts(repo, plugin_root)
@@ -235,6 +267,10 @@ def build_claude_code(root: Path, repo: Path, skills_dir: Path, methodologies_di
 def build_claude_code_skills(root: Path, repo: Path, skills_dir: Path, methodologies_dir: Path) -> None:
     platform_root = root / "claude-code"
     copy_tree_filtered(skills_dir, platform_root / "skills")
+    copy_using_mindthus_conditional_primitives(
+        methodologies_dir,
+        platform_root / "skills" / "using-mindthus",
+    )
     copy_tree_filtered(methodologies_dir, platform_root / "docs" / "methodologies")
     copy_license_files(repo, platform_root)
     copy_release_scripts(repo, platform_root)
@@ -244,6 +280,11 @@ def build_codex(root: Path, repo: Path, skills_dir: Path, agents_file: Path, met
     platform_root = root / "codex"
     replacements = skill_path_replacements("skills/mindthus")
     copy_tree_filtered(skills_dir, platform_root / "skills" / "mindthus", replacements)
+    copy_using_mindthus_conditional_primitives(
+        methodologies_dir,
+        platform_root / "skills" / "mindthus" / "using-mindthus",
+        replacements,
+    )
     copy_tree_filtered(
         methodologies_dir,
         platform_root / "docs" / "methodologies",
@@ -318,6 +359,10 @@ def build_codex_plugin(root: Path, repo: Path, skills_dir: Path, methodologies_d
     for skill_name in SKILL_NAMES:
         jsonl_allowlist = {Path("templates/evidence.jsonl")} if skill_name == "tplan" else set()
         copy_tree_filtered(skills_dir / skill_name, plugin_root / "skills" / skill_name, jsonl_allowlist=jsonl_allowlist)
+    copy_using_mindthus_conditional_primitives(
+        methodologies_dir,
+        plugin_root / "skills" / "using-mindthus",
+    )
     copy_tree_filtered(skills_dir / "_runtime", plugin_root / "_runtime")
     copy_tree_filtered(
         methodologies_dir,
@@ -332,6 +377,11 @@ def build_opencode(root: Path, repo: Path, skills_dir: Path, agents_file: Path, 
     platform_root = root / "opencode"
     replacements = skill_path_replacements(".opencode/skills/mindthus")
     copy_tree_filtered(skills_dir, platform_root / ".opencode" / "skills" / "mindthus", replacements)
+    copy_using_mindthus_conditional_primitives(
+        methodologies_dir,
+        platform_root / ".opencode" / "skills" / "mindthus" / "using-mindthus",
+        replacements,
+    )
     copy_tree_filtered(
         methodologies_dir,
         platform_root / "docs" / "methodologies",

--- a/scripts/log-mindthus-runtime.py
+++ b/scripts/log-mindthus-runtime.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 
-VERSION = "1.4.3"
+VERSION = "1.4.5"
 RELATIVE_FILES = (
     "skills/using-mindthus/SKILL.md",
     "skills/using-mindthus/resources/calibration-pairs.yaml",

--- a/skills/using-mindthus/SKILL.md
+++ b/skills/using-mindthus/SKILL.md
@@ -2,107 +2,140 @@
 name: using-mindthus
 description: Use when any Mindthus judgment lens may apply; strategic/path/control/framing ambiguity before choosing SELA, MPG, EDSP, WAE, TVG, 3L5S, or tplan. Entry Triage hard-judgment cues;whole-object reduction, forced structural binary, repeated local repair, no-data numeric comparison
 ---
+
 ## Core Claim
-Truth Orientation / 真相优先:pursue facts and truth over agreement;user input is signal, constraint, or hypothesis; not evidence by itself
+
+Truth Orientation / 真相优先: pursue facts and truth over agreement. User input is
+signal, constraint, or hypothesis; not evidence by itself.
 
 ## Mainline
-Premise Calibration / 前置校准:不是独立方法论;只帮助选择;真实对象;底层约束;目标函数
+
+Premise Calibration / 前置校准 is not a method. Before lens choice, check
+真实对象, 底层约束, and 目标函数.
+
+Before routing, classify:
+
+1. Direct execution / 直接执行: clear, low-risk, fact-sufficient; Do not use Mindthus.
+2. Information acquisition / 信息补全: missing facts, files, runtime proof, platform rules,
+   or clarification; acquire evidence first.
+3. Mindthus intervention / Mindthus 介入: a hard judgment point changes definition,
+   structure, strategy, path, control, artifact value, Mission state, or repair action.
 
 ### Input Framing Audit / 输入定框审计
-强约束入口协议:When frame-risk exists,在进入判断之前，先检查当前问题是否已经被提问方式绑到错误层级
-Frame Fitness Check / 定框适配检查: local frame trying to own global judgment.
-Inputs:local frame;local-frame capture;locally true;wrong level;implementation-layer truth;definition-layer truth.
-Outcomes:preserve frame;qualify frame;reframe;block pending evidence;can wake `sela`;does not require a full SELA run;not keyword rules;No frame-risk signal, no frame check.
-General frame rule / 通用定框规则:any locally true frame;agent inference, method routing, tests, metrics, artifacts, or implementation details;must earn global explanatory authority before it can define the whole object
-Original Prompt Contract / 原始有效提示词合同:legacy prompt template;not the judgment center;first task is not answering;First task: judge whether the user led you to the wrong level;internal audit order: true_question -> implicit_premises -> local_validity_and_layer_shift -> reframed_question -> formal_answer;leading_point
-Audit discipline;A clever paragraph is not an audit;Question level before opinion;audit hidden;Do not answer as a soft commentary fallback;step outside the user's narrative;level-correct judgment;Forbidden substitute:fluent half-right verdict;runtime-only caveat;score-as-concession
-Routing effect:preserve frame,qualify frame,reframe,block pending evidence.No execution impact:omit frame check
-Entry Triage / 入口分诊:semantic families in shared-primitives;not keywords.
 
-### AOP Aspect Activation / 切面唤起
-`scripts/primitives/check.py`:shape reminder;not semantic judge;before-route/before-answer;Auxiliary checks belong inside step 3;never become a new judgment center
-Aspect Ownership Matrix/切面主导权矩阵:judgment_owner conflict=>one thesis
+强约束入口协议: Run only with both frame-risk and execution impact; then
+在进入判断之前，先检查当前问题是否已经被提问方式绑到错误层级.
 
-### Partial Truth Capture / 局部真相捕获
-A locally true observation must not own the whole explanation;scope_not_downgrade
-Whole Elephant Protocol / 全象流程;Whole Elephant hard gate:triad first(Compact Semantic Triad / 三根硬支柱:canonical_object;result_controller;misdirection_if_local_wins);validation failure blocks formal answer;do not route local-truth essence reduction to narrower method, including WAE, before Whole Elephant audit
-Consequence probe:Contrastive Consequence Probe / 后果对比探针;local_frame_wins;whole_object_wins;better_direction_for_target
-Internal Whole Elephant contract:MUST build compact audit before formal_answer;triad+probe;validation_command;output_evidence
-Audit Hidden By Default / 审计默认内隐:full audit JSON internal by default;visible output starts with formal answer;expand only when user asks, validation fails, or handoff/debug needs it
-Validator path rule:Do not claim validation passed unless the command actually ran;No command evidence, no validation-passed claim.If the command cannot run, use explicit not_run_fallback with fallback_reason+self_check_evidence;do not fake command evidence.
+Frame Fitness Check / 定框适配检查 tests whether a locally true frame claims global authority.
+This is not a keyword rule. Set `frame_status` to `clean / biased /
+overloaded / malformed`, then `preserve frame`, `qualify frame`, `reframe`, or
+`block pending evidence`. Triggered audits record `routing_decision`. No frame-risk
+signal, no frame check; no execution impact, omit the frame check.
 
-### Formal Answer Gate
-Core Thesis Extraction / 主判断收束:formal_answer must start with a one-sentence core thesis
-First Sentence Stress Test / 首句主判断压力测试:global_thesis_first;local_truth_after;target_result+final_say/result_owner+optimization_consequence;controller_shift;result_controller_viewpoint;no second-question gap;visible first sentence must be corrected_thesis;not an audit field list
-Definition Authority Adjudication / 定义权裁决:first=object+authority;decision_context_owner;no_both_right;3Q(local/result/wrong_opt);pressure+bar;tradeoff=>struct
-Essence Wording Guard / 本质措辞护栏:corrected thesis must reject false essence claims
-Explanatory Authority Check / 解释权校准:full_object,local_frame_role,authority_status,global_owner,downgraded_use,owns_explanation,contributes_locally,misclaims_authority,blocked_by_missing_evidence;local correctness is not explanatory authority
-Dominant Carrier Check / 主导承载校准:target_result,primary_result_bearer,stability_basis,carrier_status:primary_carrier/supporting_surface/incidental_signal
-System Subject Check / 系统主体校准:visible actor,system_object,governing_structure,actor_role,subject_status,misassigned_subject;surface caveat is not enough.Non-Mirror Correction / 非镜像纠错;Failure Channel / 失败通道;Anti-Sycophancy / 反谄媚;guardrails must not become the core
-internal result:true_question,packed_premises/implicit_premises,layer_risks/local_validity_and_layer_shift,frame_status,reframed_question,routing_decision;`clean / biased / overloaded / malformed`
+Original Prompt Contract / 原始有效提示词合同 is not the judgment center. Judge whether
+the user led you to the wrong level, then reframe and answer. Keep the audit hidden; soft
+commentary is no substitute.
 
-### 最小充分镜头
-先尊重用户给出的目标函数;若用户未给出;默认效率优先;最小充分镜头:不要为了形式;shared-primitives.md
+Entry Triage / 入口分诊 is a thin semantic-family index, not keywords. Read its register
+whenever a hard cue may change route, evidence, owner, or stop; cue conflict is unnecessary.
 
-### Skill 路由
-.
-#### Intervention Boundary / 介入边界
-Direct execution / 直接执行:do not use Mindthus.Information acquisition / 信息补全:facts, files, data, runtime proof, or user clarification.Mindthus intervention / Mindthus 介入:hard judgment point
-Method Reference Boundary / 方法引用边界:method name in an inspection request is evidence scope, not route ownership;conversation forensics;rubric reference;do not say the current task is using MPG merely because it checks MPG-AQM;separate target session evidence from current confirmation request
+### Partial Truth And Visible Answer
 
-#### Judgment Object Routing / 判断对象路由
-Problem-definition failure;False binary or structural ambiguity;Long-term system efficiency versus local advantage;Qualified mainline with path/counter-force exposure;Agentic-system control-boundary mismatch;Bounded artifact with thin practical value;Mission runtime state;Repeated local repair
+Partial Truth Capture / 局部真相捕获: A locally true observation must not own the whole
+explanation. Scope correction is not object downgrading.
 
-#### `sela`
-Long-term system efficiency versus local advantage;系统级费效比;短视选择
-#### `mpg`
-Qualified mainline with path/counter-force exposure;mainline + proxy/carrier + concentrated exposure + now/continue/commit decision;concentrated scarce-resource exposure;not domain-specific;`mpg`;Do not use MPG when there is no actor, carrier, exposure, or path decision.
-#### `3l5s`
-Problem-definition failure;问题还不清楚;Discovery -> Definition
-#### `tplan`
-tplan requires Mission-level runtime state;ordinary complexity is not enough;do not proactively activate;durable task state;human-in-loop authority
-#### `edsp`
-False binary or structural ambiguity;A/B 都像对;Extreme Deduction
-#### `wae`
-Agentic-system control-boundary mismatch -> `wae`;Workflow / Agentic / Evidence;控制权;No agentic system, no WAE.No controller mismatch, no WAE
-#### `tvg`
-Bounded artifact with thin practical value;结构完整但实质浅薄;TVG requires a bounded artifact whose practical value is thin and whose expected value can be named;vague dissatisfaction or ordinary writing quality;No bounded artifact value-gain target, no TVG.No active TVG loop, no TVG audit
+Essence/definition judgments use Whole Elephant hard gate and the Compact
+Semantic Triad / 三根硬支柱 before formal_answer: `canonical_object`, `result_controller`,
+and `misdirection_if_local_wins`.
 
-#### Wake-Up Probes / 唤醒探针
-strategic, path-bearing, or structurally ambiguous:`SELA` wake-up;`MPG` wake-up;`EDSP` wake-up.
-MPG-unpack:scalar-commitment=>mainline/carrier/path/exposure/commitment;mainline+proxy/carrier+concentrated scarce-resource exposure+commit;support-only.
-Do not route through `3l5s`. Do not let `wae` absorb ordinary conceptual, organizational, product, or structural boundaries.
-Do not run `tvg`. Do not route to `tvg` merely because the user asks for an audit, review, or check.
+Compare `local_frame_wins`, `whole_object_wins`, and `better_direction_for_target` before
+narrower routing.
 
-#### Context Injection Point / 上下文注入口
-user_preference,long_term_objective,risk_posture,authority_boundary;does not implement memory;storage, retrieval, ranking;current user input takes priority;must not silently override
+Formal Answer Gate:
 
-#### Judgment Constraint Recognition / 判断约束识别
-Facts and evidence constrain factual claims.Values and preferences constrain priorities.Interests and incentives constrain stakeholder interpretation.Emotional signals constrain attention.Risk posture and reversibility constrain action strength.Authority boundaries constrain who may decide.do not let values or emotion assert factual claims
+- Core Thesis Extraction / 主判断收束: global thesis, result owner, and consequence first;
+  local truth follows.
+- Definition Authority Adjudication / 定义权裁决: name object and authority; test local
+  truth, result control, and wrong optimization.
+- Conditional verdicts commit to the active branch; user-owned `acceptable_tradeoff`
+  gets a structured tradeoff, not a forced verdict.
+- Social pressure raises the evidence bar; it never transfers definition authority.
 
-#### Pressure Surface Check / 施压面检查
-Pressure is not a standalone route;low-risk deterministic.Perspective Pressure handles single-view, incentive, or game-theoretic.SELA and EDSP own role pressure;MPG owns qualified-mainline path volatility;TVG owns bounded-artifact value pressure;Evidence / Claim Ceiling owns proof limits;Anti-Spiral owns repeated local repair pressure;owner, reason, and execution effect
+Audit Hidden By Default / 审计默认内隐: expose only on request, validation failure, or
+handoff/debug. Validation checks shape, not truth. No command evidence, no passed claim;
+use `not_run_fallback`.
 
-#### Expression Discipline / 表达纪律
-Approximate Quantified Mapping / 非精准量化显影 can be used inside an existing judgment owner;active method keeps decision authority;does not become the judgment owner.
-Use it only when the relationship is complex enough. hypothetical numbers;not factual measurements;do not compute decisions.
-skip it for simple adjectives;plain language is enough.
-MPG+AQM trigger:variables are many/dominant factor/not generic balance;after the one-sentence thesis add visible AQM snapshot / 显影快照:mainline strength/path resistance/carrier fragility/information gap/trigger strength;stage/probe, not commit.
+### Skill Routing
 
-#### Method Arbitration / 方法仲裁
-Outcomes:`dominate`,`defer`,`degrade`,`block`,`stop`.
-Conflicts:TVG-vs-Anti-Spiral;SELA-vs-WAE;EDSP-vs-evidence;3L5S-vs-direct-execution;MPG-vs-AQM.
-SELA and MPG are sibling strategic lenses;SELA qualifies system-efficiency direction pressure;MPG qualifies path-carrying action.
-Common order: SELA calibrates direction before MPG tests carrier/path;sequence not hierarchy.
-SELA must not swallow MPG-ready carrier/path/exposure/commitment questions. MPG must not replace SELA for naked system-efficiency direction judgment.
-MPG route handoff: when `mpg` dominates and system-efficiency direction pressure is present, carry `SELA support + MPG dominate` into the answer plan.
-Do not leave SELA support implicit after selecting MPG;AQM visibility map or skipped reason;One final answer, two distinct judgment surfaces;Approximate Quantified Mapping only makes variables visible.
+Route by the active judgment object, not method name, keyword, or artifact.
 
-#### Execution Impact / 执行影响
-strategy;risk handling;evidence requirement;next action;stopping condition;method choice;handoff packet.If a judgment changes none of these, information acquisition, clarification, or sharper routing
+| Owner | Dominates when |
+| --- | --- |
+| `3l5s` | Problem-definition failure or work too large to execute. |
+| `edsp` | False binary or structural ambiguity; A/B 都像对. |
+| `sela` | Long-term system efficiency versus local advantage; carrier/path action defers to MPG. |
+| `mpg` | Mainline plus carrier, exposure, path volatility, and commitment; no carrier/exposure/path, no MPG. |
+| `wae` | Agentic-system Workflow / Agentic / Evidence mismatch; no controller mismatch, no WAE. |
+| `tvg` | Bounded artifact is thin with a named value-gain target; TVG audit needs an active loop; external audits stay object-routed. |
+| `tplan` | Durable Mission state, recovery, or human authority; ordinary complexity is insufficient. |
+
+Method Reference Boundary / 方法引用边界: a method named in evidence review sets scope,
+not route ownership. Separate target session from confirmation.
+
+Repeated local repair triggers Anti-Spiral / 反螺旋入口: before another patch, return to
+upstream problem, evidence, and stopping condition.
+
+### Supporting Primitives
+
+- Aspect Ownership Matrix / 切面主导权矩阵: owner conflict yields one visible thesis;
+  others degrade to constraint or support.
+- Context Injection Point / 上下文注入口: context constrains judgment; it neither
+  implements memory nor overrides current input.
+- Judgment Constraint Recognition / 判断约束识别: facts constrain claims; values set
+  priorities; risk sets action strength; authority determines who decides.
+- Pressure Surface Check / 施压面检查: pressure is not a route; assign its owner.
+- Approximate Quantified Mapping / 非精准量化显影 exposes variables inside an existing
+  owner. Hypothetical numbers must not prove facts or compute decisions.
+- MPG Scalar Commitment Unpack is support-only: expose
+  `mainline / carrier / path_volatility / exposure / commitment` before MPG routing.
+
+### Method Arbitration / 方法仲裁
+
+Use `dominate`, `defer`, `degrade`, `block`, or `stop`. SELA owns direction pressure; MPG
+owns path-carrying action. Other conflicts belong to the owner changing the problem,
+evidence gate, action, or stop.
+
+### Execution Impact / 执行影响
+
+Method use must change strategy, risk handling, evidence requirement, next action,
+stopping condition, method choice, or handoff packet. If none changes, execute directly,
+acquire information, clarify, or reroute.
 
 ## Guardrails
-docs/methodologies/shared-primitives.md;反螺旋入口;fidelity contract;resources/fidelity-contract.md;templates/fidelity-output.json;validate_using_mindthus_output.py;validation is not semantic approval
+
+Guardrails support the mainline; they do not become a new judgment center.
+
+### Conditional Resources / Runtime Support
+
+Do not preload every resource. Read only what resolves active uncertainty:
+
+Portable alias: `resources/primitives/`.
+
+- frame or level: `docs/methodologies/primitives/frame-fitness-check.md`;
+- trigger family or route: `docs/methodologies/primitives/entry-triage.md`;
+- competing owners: `docs/methodologies/primitives/aspect-ownership.md`;
+- actor/timing/target/tradeoff: `docs/methodologies/primitives/decision-context-calibration.md`;
+- local truth claiming whole-object authority:
+  `docs/methodologies/primitives/whole-elephant-protocol.md`;
+- pressure or AQM: `docs/methodologies/primitives/expression-pressure-and-gates.md`;
+- scalar commitment: `docs/methodologies/primitives/mpg-scalar-commitment-unpack.md`;
+- activation shape: `python3 scripts/primitives/check.py --event before-route --method using-mindthus`;
+  rerun with `--event before-answer` after frame/partial-truth activation; never decides semantics;
+- structured runtime validation: read the fidelity contract at
+  `resources/fidelity-contract.md`; use `templates/fidelity-output.json` and
+  `validate_using_mindthus_output.py`.
 
 ## Boundaries
-No hard judgment point, no Mindthus. Missing facts first. Named method in evidence review is reference, not route owner.
+
+No hard judgment point, no Mindthus. Missing facts first. Stop when another method owns
+the decision or continued analysis lacks a value-gain hypothesis.

--- a/tests/test_log_mindthus_runtime.py
+++ b/tests/test_log_mindthus_runtime.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "log-mindthus-runtime.py"
-CURRENT_VERSION = "1.4.3"
+CURRENT_VERSION = "1.4.5"
 
 
 USING_TEXT = """\

--- a/tests/test_mindthus_router_contract.py
+++ b/tests/test_mindthus_router_contract.py
@@ -15,6 +15,37 @@ def _read_shared_primitive_docs() -> str:
     return "\n".join(parts)
 
 
+def _read_using_mindthus_contract() -> str:
+    """Return the preload entry plus details it explicitly loads on demand."""
+    skill_dir = REPO / "skills" / "using-mindthus"
+    return "\n".join(
+        (
+            (skill_dir / "SKILL.md").read_text(encoding="utf-8"),
+            _read_shared_primitive_docs(),
+            (skill_dir / "resources" / "fidelity-contract.md").read_text(
+                encoding="utf-8"
+            ),
+        )
+    )
+
+
+def _parse_using_mindthus_routes(text: str) -> dict[str, str]:
+    """Parse the compact two-column owner table from the preload entry."""
+    start = text.index("### Skill Routing")
+    rows: dict[str, str] = {}
+    for line in text[start:].splitlines():
+        if not line.startswith("|"):
+            if rows:
+                break
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if cells == ["Owner", "Dominates when"] or set(cells) == {"---"}:
+            continue
+        if len(cells) == 2:
+            rows[cells[0].strip("`")] = cells[1]
+    return rows
+
+
 def _skill_description(skill_name: str) -> str:
     text = (REPO / "skills" / skill_name / "SKILL.md").read_text(encoding="utf-8")
     _, frontmatter, _ = text.split("---", 2)
@@ -98,11 +129,12 @@ class MindthusRouterContractTests(unittest.TestCase):
         )
         for path in surfaces:
             text = path.read_text(encoding="utf-8")
-            for phrase in (
-                "Truth Orientation / 真相优先",
+            compact = " ".join(text.split()).lower()
+            self.assertIn("Truth Orientation / 真相优先", text)
+            self.assertIn(
                 "user input is signal, constraint, or hypothesis; not evidence by itself",
-            ):
-                self.assertIn(phrase, text, f"{path} missing {phrase!r}")
+                compact,
+            )
             self.assertTrue(
                 _states_truth_over_agreement(text),
                 f"{path} must state the truth-over-agreement principle",
@@ -110,37 +142,48 @@ class MindthusRouterContractTests(unittest.TestCase):
 
     def test_using_mindthus_defines_premise_calibration_as_pre_route_action(self):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
-        self.assertIn("Premise Calibration", text)
-        self.assertIn("前置校准", text)
-        self.assertIn("不是独立方法论", text)
-        self.assertIn("只帮助选择", text)
-        self.assertIn("真实对象", text)
-        self.assertIn("底层约束", text)
-        self.assertIn("目标函数", text)
+        for phrase in (
+            "Premise Calibration / 前置校准",
+            "is not a method",
+            "Before lens choice",
+            "真实对象",
+            "底层约束",
+            "目标函数",
+        ):
+            self.assertIn(phrase, text)
 
     def test_input_framing_audit_is_strong_entry_protocol_inside_using_mindthus(self):
         using = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
+        using_compact = " ".join(using.split())
         primitives = _read_shared_primitive_docs()
         agents = (REPO / "AGENTS.md").read_text(encoding="utf-8")
 
         for phrase in (
             "Input Framing Audit / 输入定框审计",
             "强约束入口协议",
-            "在进入判断之前，先检查当前问题是否已经被提问方式绑到错误层级",
-            "true_question",
-            "packed_premises",
-            "layer_risks",
+            "在进入判断之前，先检查当前问题是否已经被",
+            "提问方式绑到错误层级",
             "frame_status",
-            "reframed_question",
             "routing_decision",
+            "Run only with both frame-risk and execution impact",
+            "Triggered audits record `routing_decision`",
             "clean / biased / overloaded / malformed",
-            "not keyword rules",
+            "not a keyword rule",
             "No frame-risk signal, no frame check",
-            "When frame-risk exists",
-            "internal result",
-            "No execution impact:omit frame check",
+            "no execution impact, omit the frame check",
+            "docs/methodologies/primitives/frame-fitness-check.md",
         ):
-            self.assertIn(phrase, using)
+            self.assertIn(phrase, using_compact)
+
+        self.assertNotIn(
+            "omit the audit only with neither frame-risk nor execution impact",
+            using_compact,
+        )
+        for phrase in (
+            "No frame-risk signal, no frame check",
+            "No execution impact, omit the frame check",
+        ):
+            self.assertIn(phrase, primitives)
 
         for phrase in (
             "Framing-risk signals, not keyword rules",
@@ -154,6 +197,10 @@ class MindthusRouterContractTests(unittest.TestCase):
             "先给结论，再让模型评价",
             "把实现层直接说成本体层",
             "把局部机制直接说成整体解释",
+            "true_question",
+            "packed_premises",
+            "layer_risks",
+            "reframed_question",
         ):
             self.assertIn(phrase, primitives)
 
@@ -177,33 +224,21 @@ class MindthusRouterContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, agents)
 
-        for phrase in (
-            "vague dissatisfaction or ordinary writing quality",
-            "MPG owns qualified-mainline path volatility",
-            "information acquisition, clarification, or sharper routing",
-            "validation is not semantic approval",
-        ):
-            self.assertIn(phrase, using)
+        self.assertIn("acquire information, clarify, or reroute", using_compact)
 
     def test_input_framing_audit_rejects_soft_commentary_fallback(self):
         using = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
+        using_compact = " ".join(using.split())
         pressure = (REPO / "tests" / "mindthus_router_pressure_tests.md").read_text(
             encoding="utf-8"
         )
 
         for phrase in (
-            "Audit discipline",
+            "Judge whether the user led you to the wrong level",
             "audit hidden",
-            "Do not answer as a soft commentary fallback",
-            "A clever paragraph is not an audit",
-            "Question level before opinion",
-            "step outside the user's narrative",
-            "level-correct judgment",
-            "First task: judge whether the user led you to the wrong level",
-            "audit order: true_question -> implicit_premises -> local_validity_and_layer_shift -> reframed_question -> formal_answer",
-            "leading_point",
+            "soft commentary is no substitute",
         ):
-            self.assertIn(phrase, using)
+            self.assertIn(phrase, using_compact)
 
         primitives = _read_shared_primitive_docs()
         for phrase in (
@@ -232,28 +267,28 @@ class MindthusRouterContractTests(unittest.TestCase):
 
     def test_input_framing_audit_productizes_original_prompt_as_mainline_protocol(self):
         using = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
+        using_compact = " ".join(using.split())
         primitives = _read_shared_primitive_docs()
 
         for phrase in (
             "description: Use when any Mindthus judgment lens may apply",
-            "General frame rule / 通用定框规则",
-            "any locally true frame",
-            "agent inference, method routing, tests, metrics, artifacts, or implementation details",
-            "must earn global explanatory authority before it can define the whole object",
             "Original Prompt Contract / 原始有效提示词合同",
-            "legacy prompt template",
             "not the judgment center",
-            "AOP Aspect Activation / 切面唤起",
-            "before-route",
-            "before-answer",
-            "Auxiliary checks belong inside step 3",
-            "never become a new judgment center",
-            "Forbidden substitute",
-            "fluent half-right verdict",
-            "runtime-only caveat",
-            "score-as-concession",
+            "Judge whether the user led you to the wrong level",
+            "then reframe and answer",
+            "docs/methodologies/primitives/frame-fitness-check.md",
         ):
-            self.assertIn(phrase, using)
+            self.assertIn(phrase, using_compact)
+
+        for phrase in (
+            "Frame Fitness Check / 定框适配检查",
+            "local-frame capture",
+            "local frame is true or useful at one level",
+            "begins controlling the global judgment",
+            "Original Prompt Contract / 原始有效提示词合同",
+            "legacy prompt template, not the judgment center",
+        ):
+            self.assertIn(phrase, primitives)
 
         for phrase in (
             "在回答前，先执行“输入审计”，不要顺着我的叙述直接推理",
@@ -277,38 +312,16 @@ class MindthusRouterContractTests(unittest.TestCase):
             encoding="utf-8"
         )
 
-        using_compact = " ".join(using.split())
         primitives_compact = " ".join(primitives.split())
         for phrase in (
-            "Explanatory Authority Check / 解释权校准",
-            "full_object",
-            "local_frame_role",
-            "authority_status",
-            "global_owner",
-            "downgraded_use",
-            "owns_explanation",
-            "contributes_locally",
-            "misclaims_authority",
-            "blocked_by_missing_evidence",
-            "Dominant Carrier Check / 主导承载校准",
-            "target_result",
-            "primary_result_bearer",
-            "stability_basis",
-            "carrier_status",
-            "primary_carrier",
-            "supporting_surface",
-            "incidental_signal",
-            "System Subject Check / 系统主体校准",
-            "visible actor",
-            "system_object",
-            "governing_structure",
-            "actor_role",
-            "subject_status",
-            "misassigned_subject",
-            "surface caveat is not enough",
-            "local correctness is not explanatory authority",
+            "Frame Fitness Check / 定框适配检查",
+            "locally true frame",
+            "claims global",
+            "authority",
+            "Definition Authority Adjudication / 定义权裁决",
+            "docs/methodologies/primitives/frame-fitness-check.md",
         ):
-            self.assertIn(phrase, using_compact)
+            self.assertIn(phrase, using)
 
         for phrase in (
             "Explanatory Authority Check / 解释权校准",
@@ -348,12 +361,7 @@ class MindthusRouterContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, primitives_compact)
 
-        section_start = using.index("Explanatory Authority Check / 解释权校准")
-        section_end = using.index("internal result", section_start)
-        authority_section = using[section_start:section_end]
-        self.assertNotIn("Script determinism check", authority_section)
-        self.assertNotIn("carrier, activation, control, state", authority_section)
-        self.assertNotIn("A/B", authority_section)
+        self.assertNotIn("Script determinism check", using)
 
         pressure_compact = " ".join(pressure.split())
         for phrase in (
@@ -393,17 +401,10 @@ class MindthusRouterContractTests(unittest.TestCase):
             "Partial Truth Capture / 局部真相捕获",
             "A locally true observation must not own the whole explanation",
             "Whole Elephant hard gate",
-            "Internal Whole Elephant contract",
-            "MUST build compact audit before formal_answer",
+            "Compact Semantic Triad / 三根硬支柱 before formal_answer",
             "Audit Hidden By Default / 审计默认内隐",
-            "full audit JSON internal by default",
-            "validation_command",
-            "output_evidence",
-            "Do not claim validation passed unless the command actually ran",
-            "No command evidence, no validation-passed claim",
-            "If the command cannot run, use explicit not_run_fallback",
-            "fallback_reason+self_check_evidence",
-            "do not fake command evidence",
+            "No command evidence, no passed claim",
+            "not_run_fallback",
         ):
             self.assertIn(phrase, using_compact)
 
@@ -502,9 +503,7 @@ class MindthusRouterContractTests(unittest.TestCase):
         using_compact = " ".join(using.split())
         for phrase in (
             "Audit Hidden By Default / 审计默认内隐",
-            "full audit JSON internal by default",
-            "visible output starts with formal answer",
-            "expand only when user asks, validation fails, or handoff/debug needs it",
+            "expose only on request, validation failure, or handoff/debug",
         ):
             self.assertIn(phrase, using_compact)
 
@@ -634,14 +633,10 @@ class MindthusRouterContractTests(unittest.TestCase):
 
         using_compact = " ".join(using.split())
         for phrase in (
-            "First Sentence Stress Test / 首句主判断压力测试",
-            "target_result+final_say/result_owner+optimization_consequence",
-            "controller_shift",
-            "no second-question gap",
-            "visible first sentence must be corrected_thesis",
-            "global_thesis_first",
-            "local_truth_after",
-            "not an audit field list",
+            "Formal Answer Gate",
+            "Core Thesis Extraction / 主判断收束",
+            "global thesis, result owner, and consequence first",
+            "local truth follows",
         ):
             self.assertIn(phrase, using_compact)
 
@@ -1010,15 +1005,22 @@ class MindthusRouterContractTests(unittest.TestCase):
             self.assertIn(phrase, text)
 
     def test_router_defines_objective_priority_and_references_minimal_lens(self):
-        for path in (REPO / "AGENTS.md", REPO / "skills" / "using-mindthus" / "SKILL.md"):
-            text = path.read_text(encoding="utf-8")
-            for phrase in (
-                "先尊重用户给出的目标函数",
-                "若用户未给出",
-                "默认效率优先",
-                "最小充分镜头",
-            ):
-                self.assertIn(phrase, text, f"{path} missing {phrase!r}")
+        agents = (REPO / "AGENTS.md").read_text(encoding="utf-8")
+        for phrase in (
+            "先尊重用户给出的目标函数",
+            "若用户未给出",
+            "默认效率优先",
+            "最小充分镜头",
+        ):
+            self.assertIn(phrase, agents)
+
+        using = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        using_compact = " ".join(using.split())
+        self.assertIn("Direct execution / 直接执行", using_compact)
+        self.assertIn("Do not use Mindthus", using_compact)
+        self.assertIn("Do not preload every resource", using_compact)
 
         primitives = _read_shared_primitive_docs()
         for phrase in (
@@ -1030,40 +1032,36 @@ class MindthusRouterContractTests(unittest.TestCase):
 
     def test_minimal_sufficient_lens_does_not_change_tplan_activation(self):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
-        start = text.index("### 最小充分镜头")
-        end = text.index("### Skill 路由", start)
+        start = text.index("## Mainline")
+        end = text.index("### Skill Routing", start)
         section = text[start:end]
         self.assertNotIn("tplan", section.lower())
 
     def test_using_mindthus_defines_intervention_boundary_before_skill_choice(self):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
+        compact = " ".join(text.split())
         for phrase in (
-            "Intervention Boundary / 介入边界",
             "Direct execution / 直接执行",
             "Information acquisition / 信息补全",
             "Mindthus intervention / Mindthus 介入",
-            "do not use Mindthus",
-            "facts, files, data, runtime proof, or user clarification",
+            "Do not use Mindthus",
+            "facts, files, runtime proof, platform rules, or",
             "hard judgment point",
         ):
-            self.assertIn(phrase, text)
+            self.assertIn(phrase, compact)
 
     def test_judgment_object_routing_precedes_individual_skill_routes(self):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
-        start = text.index("#### Judgment Object Routing / 判断对象路由")
-        first_skill = text.index("#### `sela`", start)
-        section = text[start:first_skill]
-        for phrase in (
-            "Problem-definition failure",
-            "False binary or structural ambiguity",
-            "Long-term system efficiency versus local advantage",
-            "Qualified mainline with path/counter-force exposure",
-            "Agentic-system control-boundary mismatch",
-            "Bounded artifact with thin practical value",
-            "Mission runtime state",
-            "Repeated local repair",
-        ):
-            self.assertIn(phrase, section)
+        self.assertLess(text.index("Route by the active judgment object"), text.index("| Owner |"))
+        routes = _parse_using_mindthus_routes(text)
+        self.assertIn("Problem-definition failure", routes["3l5s"])
+        self.assertIn("False binary or structural ambiguity", routes["edsp"])
+        self.assertIn("Long-term system efficiency versus local advantage", routes["sela"])
+        self.assertIn("carrier, exposure, path volatility, and commitment", routes["mpg"])
+        self.assertIn("Agentic-system", routes["wae"])
+        self.assertIn("Bounded artifact", routes["tvg"])
+        self.assertIn("Mission state", routes["tplan"])
+        self.assertIn("Repeated local repair", text)
 
     def test_all_method_skill_entrypoints_have_using_mindthus_route_heading(self):
         using = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
@@ -1072,18 +1070,14 @@ class MindthusRouterContractTests(unittest.TestCase):
             for path in (REPO / "skills").glob("*/SKILL.md")
             if path.parent.name not in {"using-mindthus"}
         }
-        for method in sorted(routed_methods):
-            self.assertIn(f"#### `{method}`", using, f"{method} missing using-mindthus route heading")
+        self.assertEqual(set(_parse_using_mindthus_routes(using)), routed_methods)
 
     def test_tvg_and_tplan_are_non_proactive_routes(self):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
-        for phrase in (
-            "TVG requires a bounded artifact",
-            "tplan requires Mission-level runtime state",
-            "do not proactively activate",
-            "ordinary complexity is not enough",
-        ):
-            self.assertIn(phrase, text)
+        routes = _parse_using_mindthus_routes(text)
+        self.assertIn("named value-gain target", routes["tvg"])
+        self.assertIn("Durable Mission state", routes["tplan"])
+        self.assertIn("ordinary complexity is insufficient", routes["tplan"])
 
     def test_wae_route_requires_agentic_system_domain_gate(self):
         skill = (REPO / "skills" / "wae" / "SKILL.md").read_text(encoding="utf-8")
@@ -1105,12 +1099,9 @@ class MindthusRouterContractTests(unittest.TestCase):
             ):
                 self.assertIn(phrase, text)
 
-        for phrase in (
-            "Agentic-system control-boundary mismatch -> `wae`",
-            "Do not let `wae` absorb ordinary conceptual, organizational, product, or structural boundaries",
-            "No agentic system, no WAE",
-        ):
-            self.assertIn(phrase, using)
+        wae_route = _parse_using_mindthus_routes(using)["wae"]
+        self.assertIn("Agentic-system Workflow / Agentic / Evidence mismatch", wae_route)
+        self.assertIn("no controller mismatch, no WAE", wae_route)
 
         for phrase in (
             "agentic systems",
@@ -1157,12 +1148,11 @@ class MindthusRouterContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, template)
 
-        for phrase in (
-            "Do not route to `tvg` merely because the user asks for an audit, review, or check",
-            "bounded artifact whose practical value is thin and whose expected value can be named",
-            "No active TVG loop, no TVG audit",
-        ):
-            self.assertIn(phrase, using)
+        tvg_route = _parse_using_mindthus_routes(using)["tvg"]
+        self.assertIn("Bounded artifact is thin", tvg_route)
+        self.assertIn("named value-gain target", tvg_route)
+        self.assertIn("TVG audit needs an active loop", tvg_route)
+        self.assertIn("external audits stay object-routed", tvg_route)
 
         for phrase in (
             "TVG 的 audit 是内部退出检查",
@@ -1175,20 +1165,17 @@ class MindthusRouterContractTests(unittest.TestCase):
         using = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(
             encoding="utf-8"
         )
+        using_compact = " ".join(using.split())
         pressure = (REPO / "tests" / "mindthus_router_pressure_tests.md").read_text(
             encoding="utf-8"
         )
 
         for phrase in (
             "Method Reference Boundary / 方法引用边界",
-            "method name in an inspection request is evidence scope, not route ownership",
-            "conversation forensics",
-            "rubric reference",
-            "do not say the current task is using MPG merely because it checks MPG-AQM",
-            "target session evidence",
-            "current confirmation request",
+            "a method named in evidence review sets scope, not route ownership",
+            "Separate target session from confirmation",
         ):
-            self.assertIn(phrase, using)
+            self.assertIn(phrase, using_compact)
 
         for phrase in (
             "Scenario 50: MPG-AQM Session Forensics Is Not MPG Route Ownership",
@@ -1248,19 +1235,41 @@ class MindthusRouterContractTests(unittest.TestCase):
 
     def test_using_mindthus_defines_low_frequency_method_wakeup_probes(self):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
-        start = text.index("#### Wake-Up Probes / 唤醒探针")
-        end = text.index("#### Context Injection Point / 上下文注入口", start)
-        section = text[start:end]
+        text_compact = " ".join(text.split())
+        entry = (
+            REPO / "docs" / "methodologies" / "primitives" / "entry-triage.md"
+        ).read_text(encoding="utf-8")
+        entry_compact = " ".join(entry.split())
+        self.assertIn("docs/methodologies/primitives/entry-triage.md", text)
+        self.assertIn(
+            "whenever a hard cue may change route, evidence, owner, or stop",
+            text_compact,
+        )
+        self.assertIn("cue conflict is unnecessary", text_compact)
+        routes = _parse_using_mindthus_routes(text)
+        self.assertEqual(set(routes), {"3l5s", "edsp", "sela", "mpg", "wae", "tvg", "tplan"})
         for phrase in (
-            "`SELA` wake-up",
-            "`MPG` wake-up",
-            "`EDSP` wake-up",
-            "Do not route through `3l5s`",
-            "Do not let `wae`",
-            "Do not run `tvg`",
-            "strategic, path-bearing, or structurally ambiguous",
+            "These families are wake-up candidates, not automatic method calls",
+            "It is not a keyword router",
+            "EDSP owns bare A/B structural choice",
+            "SELA owns local expertise versus automation scale",
+            "AQM stays inside the active judgment owner",
+            "If it changes none of these, skip it",
         ):
-            self.assertIn(phrase, section)
+            self.assertIn(phrase, entry_compact)
+
+    def test_using_mindthus_keeps_before_route_and_before_answer_activation_handoff(self):
+        text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        compact = " ".join(text.split())
+        for phrase in (
+            "python3 scripts/primitives/check.py --event before-route --method using-mindthus",
+            "--event before-answer",
+            "after frame/partial-truth activation",
+            "never decides semantics",
+        ):
+            self.assertIn(phrase, compact)
 
     def test_sela_mpg_sibling_activation_for_path_carrying_commitments(self):
         using = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
@@ -1268,20 +1277,12 @@ class MindthusRouterContractTests(unittest.TestCase):
             REPO / "tests" / "mpg" / "scalar_commitment_unpack_manual_review_cases.md"
         ).read_text(encoding="utf-8")
 
+        routes = _parse_using_mindthus_routes(using)
+        self.assertIn("carrier/path action defers to MPG", routes["sela"])
+        self.assertIn("carrier, exposure, path volatility, and commitment", routes["mpg"])
         using_compact = " ".join(using.split())
-        for phrase in (
-            "SELA and MPG are sibling strategic lenses",
-            "SELA qualifies system-efficiency direction pressure",
-            "MPG qualifies path-carrying action",
-            "Common order: SELA calibrates direction before MPG tests carrier/path;sequence not hierarchy",
-            "SELA must not swallow MPG-ready carrier/path/exposure/commitment questions",
-            "MPG must not replace SELA for naked system-efficiency direction judgment",
-            "MPG route handoff: when `mpg` dominates and system-efficiency direction pressure is present, carry `SELA support + MPG dominate` into the answer plan",
-            "Do not leave SELA support implicit after selecting MPG",
-            "AQM visibility map or skipped reason",
-            "One final answer, two distinct judgment surfaces",
-        ):
-            self.assertIn(phrase, using_compact)
+        self.assertIn("SELA owns direction pressure", using_compact)
+        self.assertIn("MPG owns path-carrying action", using_compact)
 
         for phrase in (
             "Sibling activation expected",
@@ -1298,13 +1299,12 @@ class MindthusRouterContractTests(unittest.TestCase):
             REPO / "tests" / "mpg" / "scalar_commitment_unpack_manual_review_cases.md"
         ).read_text(encoding="utf-8")
 
-        using_compact = " ".join(using.split())
         for phrase in (
-            "MPG-unpack:scalar-commitment",
-            "mainline/carrier/path/exposure/commitment",
+            "MPG Scalar Commitment Unpack",
+            "mainline / carrier / path_volatility / exposure / commitment",
             "support-only",
         ):
-            self.assertIn(phrase, using_compact)
+            self.assertIn(phrase, using)
 
         primitives_compact = " ".join(primitives.split())
         for phrase in (
@@ -1423,32 +1423,30 @@ class MindthusRouterContractTests(unittest.TestCase):
 
     def test_context_injection_point_is_interface_not_memory_implementation(self):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
+        compact = " ".join(text.split())
+        agents = (REPO / "AGENTS.md").read_text(encoding="utf-8")
         for phrase in (
             "Context Injection Point / 上下文注入口",
-            "does not implement memory",
-            "storage, retrieval, ranking",
-            "current user input takes priority",
-            "must not silently override",
-            "user_preference",
-            "long_term_objective",
-            "risk_posture",
-            "authority_boundary",
+            "neither implements memory nor overrides current input",
         ):
-            self.assertIn(phrase, text)
+            self.assertIn(phrase, compact)
+        for phrase in (
+            "当前用户输入优先",
+            "不能静默覆盖本轮明确指令",
+        ):
+            self.assertIn(phrase, agents)
 
     def test_using_mindthus_defines_judgment_constraint_recognition(self):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
+        compact = " ".join(text.split())
         for phrase in (
             "Judgment Constraint Recognition / 判断约束识别",
-            "Facts and evidence constrain factual claims",
-            "Values and preferences constrain priorities",
-            "Interests and incentives constrain stakeholder interpretation",
-            "Emotional signals constrain attention",
-            "Risk posture and reversibility constrain action strength",
-            "Authority boundaries constrain who may decide",
-            "do not let values or emotion assert factual claims",
+            "facts constrain claims",
+            "values set priorities",
+            "risk sets action strength",
+            "authority determines who decides",
         ):
-            self.assertIn(phrase, text)
+            self.assertIn(phrase, compact)
 
     def test_using_mindthus_defines_method_arbitration_actions(self):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
@@ -1501,7 +1499,7 @@ class MindthusRouterContractTests(unittest.TestCase):
             "stopping condition",
             "method choice",
             "handoff packet",
-            "If a judgment changes none of these",
+            "If none changes",
         ):
             self.assertIn(phrase, text)
 
@@ -1509,14 +1507,9 @@ class MindthusRouterContractTests(unittest.TestCase):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
         for phrase in (
             "Pressure Surface Check / 施压面检查",
-            "Pressure is not a standalone route",
-            "low-risk deterministic",
-            "Perspective Pressure handles single-view, incentive, or game-theoretic",
-            "SELA and EDSP own role pressure",
-            "TVG owns bounded-artifact value pressure",
-            "Evidence / Claim Ceiling owns proof limits",
-            "Anti-Spiral owns repeated local repair pressure",
-            "owner, reason, and execution effect",
+            "pressure is not a route",
+            "assign its owner",
+            "docs/methodologies/primitives/expression-pressure-and-gates.md",
         ):
             self.assertIn(phrase, text)
 
@@ -1550,26 +1543,38 @@ class MindthusRouterContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, primitives)
 
-        for text in (using, agents):
-            for phrase in (
-                "Approximate Quantified Mapping",
-                "非精准量化显影",
-                "hypothetical numbers",
-                "not factual measurements",
-                "do not compute decisions",
-            ):
-                self.assertIn(phrase, text)
+        for phrase in (
+            "Approximate Quantified Mapping",
+            "非精准量化显影",
+            "Hypothetical numbers",
+            "must not prove facts or compute decisions",
+        ):
+            self.assertIn(phrase, using)
+        for phrase in (
+            "Approximate Quantified Mapping",
+            "非精准量化显影",
+            "hypothetical numbers are not factual measurements",
+            "do not compute decisions",
+        ):
+            self.assertIn(phrase, agents)
 
-        start = using.index("#### Judgment Object Routing / 判断对象路由")
-        end = using.index("#### Context Injection Point / 上下文注入口", start)
-        routing_table = using[start:end]
-        self.assertNotIn("Approximate Quantified Mapping", routing_table)
-        self.assertNotIn("非精准量化显影", routing_table)
+        routes = _parse_using_mindthus_routes(using)
+        self.assertNotIn("Approximate Quantified Mapping", " ".join(routes.values()))
+        self.assertNotIn("非精准量化显影", " ".join(routes.values()))
 
     def test_aqm_snapshot_is_visible_when_user_asks_for_dominant_variables(self):
         using = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(
             encoding="utf-8"
         )
+        details = "\n".join(
+            (
+                _read_shared_primitive_docs(),
+                (REPO / "docs" / "methodologies" / "mpg.md").read_text(
+                    encoding="utf-8"
+                ),
+            )
+        )
+        self.assertIn("docs/methodologies/primitives/expression-pressure-and-gates.md", using)
         for phrase in (
             "visible AQM snapshot / 显影快照",
             "variables are many",
@@ -1583,7 +1588,7 @@ class MindthusRouterContractTests(unittest.TestCase):
             "trigger strength",
             "stage/probe, not commit",
         ):
-            self.assertIn(phrase, using)
+            self.assertIn(phrase, details)
 
     def test_game_theory_is_not_a_standalone_skill(self):
         for name in ("game-theory", "game_theory", "gametheory"):
@@ -1626,12 +1631,9 @@ class MindthusRouterContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, primitives)
 
-        for phrase in (
-            "can be used inside an existing judgment owner",
-            "active method keeps decision authority",
-            "does not become the judgment owner",
-        ):
-            self.assertIn(phrase, using)
+        using_compact = " ".join(using.split())
+        self.assertIn("exposes variables inside an existing owner", using_compact)
+        self.assertIn("must not prove facts or compute decisions", using_compact)
 
     def test_approximate_quantified_mapping_has_anti_overuse_threshold(self):
         primitives = _read_shared_primitive_docs()
@@ -1651,12 +1653,7 @@ class MindthusRouterContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, primitives)
 
-        for phrase in (
-            "Use it only when the relationship is complex enough",
-            "skip it for simple adjectives",
-            "plain language is enough",
-        ):
-            self.assertIn(phrase, using)
+        self.assertIn("docs/methodologies/primitives/expression-pressure-and-gates.md", using)
 
         for phrase in (
             "Scenario 16: Simple Claim Skips Mapping",
@@ -1720,9 +1717,20 @@ class MindthusRouterContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, primitives)
 
+        agents = (REPO / "AGENTS.md").read_text(encoding="utf-8")
+        self.assertIn(primitives_path, agents)
+        using = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        for linked_detail in (
+            "docs/methodologies/primitives/frame-fitness-check.md",
+            "docs/methodologies/primitives/entry-triage.md",
+            "docs/methodologies/primitives/expression-pressure-and-gates.md",
+        ):
+            self.assertIn(linked_detail, using)
+
         for path in (REPO / "AGENTS.md", REPO / "skills" / "using-mindthus" / "SKILL.md"):
             text = path.read_text(encoding="utf-8")
-            self.assertIn(primitives_path, text, f"{path} should link cognitive primitives")
             for copied_definition in (
                 "每个抽象概念至少给出一种支撑",
                 "Can this be answered directly?",
@@ -1840,25 +1848,25 @@ class MindthusRouterContractTests(unittest.TestCase):
 
     def test_skill_routing_surface_preserves_pre_refactor_route_triggers(self):
         using = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(encoding="utf-8")
+        routes = _parse_using_mindthus_routes(using)
         expected_routes = {
-            "sela": ("系统级费效比", "短视选择"),
-            "mpg": ("Qualified mainline with path/counter-force exposure", "`mpg`"),
-            "3l5s": ("问题还不清楚", "Discovery -> Definition"),
-            "tplan": ("durable task state", "human-in-loop authority"),
-            "edsp": ("A/B 都像对", "Extreme Deduction"),
-            "wae": ("Workflow / Agentic / Evidence", "控制权"),
-            "tvg": ("结构完整但实质浅薄", "bounded artifact"),
+            "sela": ("system efficiency", "local advantage"),
+            "mpg": ("carrier", "path volatility", "commitment"),
+            "3l5s": ("Problem-definition failure", "too large to execute"),
+            "tplan": ("Mission state", "human authority"),
+            "edsp": ("A/B 都像对", "structural ambiguity"),
+            "wae": ("Workflow / Agentic / Evidence", "controller mismatch"),
+            "tvg": ("Bounded artifact", "value-gain target"),
         }
         for skill, phrases in expected_routes.items():
-            self.assertIn(f"#### `{skill}`", using)
             for phrase in phrases:
-                self.assertIn(phrase, using, f"{skill} route missing {phrase!r}")
+                self.assertIn(phrase, routes[skill], f"{skill} route missing {phrase!r}")
 
     def test_cognitive_primitives_are_active_in_their_primary_owner_surfaces(self):
         surfaces = {
             "Minimal Sufficient Lens": (
                 REPO / "skills" / "using-mindthus" / "SKILL.md",
-                ("最小充分镜头", "shared-primitives.md", "不要为了形式"),
+                ("Direct execution / 直接执行", "Do not use Mindthus", "Do not preload every resource"),
             ),
             "Evidence / Claim Ceiling": (
                 REPO / "skills" / "wae" / "SKILL.md",
@@ -1888,17 +1896,16 @@ class MindthusRouterContractTests(unittest.TestCase):
                 REPO / "skills" / "using-mindthus" / "SKILL.md",
                 (
                     "Frame Fitness Check",
-                    "local frame",
+                    "locally true frame",
                     "preserve frame",
                     "qualify frame",
                     "reframe",
                     "block pending evidence",
-                    "SELA",
                 ),
             ),
         }
         for primitive, (path, phrases) in surfaces.items():
-            text = path.read_text(encoding="utf-8")
+            text = " ".join(path.read_text(encoding="utf-8").split())
             for phrase in phrases:
                 self.assertIn(phrase, text, f"{primitive} inactive in {path}: {phrase!r}")
 
@@ -1930,18 +1937,15 @@ class MindthusRouterContractTests(unittest.TestCase):
 
         for phrase in (
             "Frame Fitness Check / 定框适配检查",
-            "local-frame capture",
             "locally true",
-            "global judgment",
+            "claims global",
+            "authority",
             "preserve frame",
             "qualify frame",
             "reframe",
             "block pending evidence",
-            "can wake `sela`",
-            "does not require a full SELA run",
             "wrong level",
-            "implementation-layer truth",
-            "definition-layer truth",
+            "docs/methodologies/primitives/frame-fitness-check.md",
         ):
             self.assertIn(phrase, using)
 

--- a/tests/test_mpg_contract.py
+++ b/tests/test_mpg_contract.py
@@ -222,30 +222,24 @@ class MpgContractTests(unittest.TestCase):
         text = (REPO / "skills" / "using-mindthus" / "SKILL.md").read_text(
             encoding="utf-8"
         )
+        compact = " ".join(text.split())
         agents = (REPO / "AGENTS.md").read_text(encoding="utf-8")
         for phrase in (
-            "Qualified mainline with path/counter-force exposure",
-            "`mpg`",
             "Long-term system efficiency versus local advantage",
-            "SELA and MPG are sibling strategic lenses",
-            "SELA qualifies system-efficiency direction pressure",
-            "MPG qualifies path-carrying action",
-            "Common order: SELA calibrates direction before MPG tests carrier/path;sequence not hierarchy",
-            "SELA must not swallow MPG-ready carrier/path/exposure/commitment questions",
-            "MPG must not replace SELA for naked system-efficiency direction judgment",
-            "Approximate Quantified Mapping only makes variables visible.",
-            "Do not use MPG when there is no actor, carrier, exposure, or path decision.",
-            "mainline + proxy/carrier + concentrated exposure + now/continue/commit decision",
-            "concentrated scarce-resource exposure",
-            "not domain-specific",
+            "carrier/path action defers to MPG",
+            "Mainline plus carrier, exposure, path volatility, and commitment",
+            "no carrier/exposure/path, no MPG",
+            "SELA owns direction pressure; MPG owns path-carrying action",
+            "Approximate Quantified Mapping / 非精准量化显影",
+            "must not prove facts or compute decisions",
         ):
-            self.assertIn(phrase, text)
-        self.assertIn("MPG vs AQM", text.replace("-", " "))
+            self.assertIn(phrase, compact)
         for phrase in (
             "MPG",
             "主线-路径博弈",
             "主线承载方案",
             "SELA 看整体趋势",
+            "direction + carrier + visibility",
         ):
             self.assertIn(phrase, agents)
 

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -90,7 +90,7 @@ class PackagingDocsTests(unittest.TestCase):
         for phrase in (
             "mindthus:tplan",
             "mindthus:*",
-            "当前仓库版本：`v1.4.3`",
+            "当前仓库版本：`v1.4.5`",
             "局部正确",
             "输入定框审计",
             "framing-risk",
@@ -782,7 +782,7 @@ class PackagingDocsTests(unittest.TestCase):
             source = marketplace["plugins"][0]["source"]
             self.assertEqual(source, "./claude-plugin")
             self.assertNotIn("..", source)
-            self.assertEqual(plugin["version"], "1.4.3")
+            self.assertEqual(plugin["version"], "1.4.5")
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "tplan" / "SKILL.md").exists())
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "mpg" / "SKILL.md").exists())
             claude_hook_config_path = out / "claude-code" / "claude-plugin" / "hooks" / "hooks.json"
@@ -870,7 +870,7 @@ class PackagingDocsTests(unittest.TestCase):
             )
             self.assertEqual(codex_marketplace["plugins"][0]["policy"]["installation"], "AVAILABLE")
             self.assertEqual(codex_plugin_manifest["name"], "mindthus")
-            self.assertEqual(codex_plugin_manifest["version"], "1.4.3")
+            self.assertEqual(codex_plugin_manifest["version"], "1.4.5")
             self.assertEqual(codex_plugin_manifest["skills"], "./skills/")
             self.assertEqual(codex_plugin_manifest["license"], "AGPL-3.0-only")
             self.assertEqual(codex_plugin_manifest["interface"]["brandColor"], "#161614")
@@ -987,8 +987,8 @@ class PackagingDocsTests(unittest.TestCase):
         script = REPO / "scripts" / "build-release-pack.py"
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            plugins = tmp_dir / "mindthus-plugins-1.4.3"
-            skills = tmp_dir / "mindthus-skills-1.4.3"
+            plugins = tmp_dir / "mindthus-plugins-1.4.5"
+            skills = tmp_dir / "mindthus-skills-1.4.5"
 
             plugin_result = subprocess.run(
                 ["python3", str(script), "--package", "plugins", "--out", str(plugins)],

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -8,6 +8,15 @@ from pathlib import Path
 
 
 REPO = Path(__file__).resolve().parents[1]
+USING_MINDTHUS_CONDITIONAL_PRIMITIVES = (
+    "frame-fitness-check.md",
+    "entry-triage.md",
+    "aspect-ownership.md",
+    "decision-context-calibration.md",
+    "whole-elephant-protocol.md",
+    "expression-pressure-and-gates.md",
+    "mpg-scalar-commitment-unpack.md",
+)
 
 
 def parse_frontmatter_mapping(text: str) -> dict[str, str]:
@@ -50,6 +59,31 @@ class PackagingDocsTests(unittest.TestCase):
         self.assertIsInstance(parsed, dict, f"{path} frontmatter must be a mapping")
         self.assertIn("name", parsed, f"{path} frontmatter missing name")
         self.assertIn("description", parsed, f"{path} frontmatter missing description")
+
+    def assert_packaged_using_mindthus_primitives(self, skill_dir: Path) -> None:
+        fidelity_contract = skill_dir / "resources" / "fidelity-contract.md"
+        self.assertTrue(
+            fidelity_contract.is_file(),
+            f"missing packaged fidelity contract: {fidelity_contract}",
+        )
+        for filename in USING_MINDTHUS_CONDITIONAL_PRIMITIVES:
+            source = (
+                REPO / "docs" / "methodologies" / "primitives" / filename
+            ).read_text(encoding="utf-8")
+            expected = source.replace(
+                "../../../skills/using-mindthus/resources/fidelity-contract.md",
+                "../fidelity-contract.md",
+            )
+            packaged = skill_dir / "resources" / "primitives" / filename
+            self.assertTrue(packaged.is_file(), f"missing packaged primitive: {packaged}")
+            packaged_text = packaged.read_text(encoding="utf-8")
+            self.assertEqual(packaged_text, expected)
+            if "../fidelity-contract.md" in packaged_text:
+                linked_contract = packaged.parent / "../fidelity-contract.md"
+                self.assertTrue(
+                    linked_contract.resolve().is_file(),
+                    f"broken packaged fidelity link: {packaged} -> {linked_contract}",
+                )
 
     def test_readme_names_current_skill_pack_and_tplan(self):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
@@ -377,12 +411,12 @@ class PackagingDocsTests(unittest.TestCase):
         )
 
     def test_using_mindthus_entrypoint_stays_thin_enough_for_attention(self):
-        budget_bytes = 11 * 1024
+        budget_bytes = 9 * 1024
         path = REPO / "skills" / "using-mindthus" / "SKILL.md"
         self.assertLessEqual(
             path.stat().st_size,
             budget_bytes,
-            "using-mindthus is the routing entrypoint; keep it under 11KiB and move long semantics to AOP primitives/scripts.",
+            "using-mindthus is the high-frequency routing entrypoint; keep it under 9KiB and move detailed semantics to conditional resources.",
         )
 
     def test_using_mindthus_entrypoint_stays_within_word_attention_budget(self):
@@ -390,9 +424,19 @@ class PackagingDocsTests(unittest.TestCase):
         word_count = len(path.read_text(encoding="utf-8").split())
         self.assertLessEqual(
             word_count,
-            1100,
-            "using-mindthus should stay under 1100 words; move detailed semantics to shared primitives, resources, or validators.",
+            900,
+            "using-mindthus should stay under 900 words; move detailed semantics to shared primitives, resources, or validators.",
         )
+
+    def test_using_mindthus_uses_progressive_disclosure_for_detail_contracts(self):
+        path = REPO / "skills" / "using-mindthus" / "SKILL.md"
+        text = path.read_text(encoding="utf-8")
+        self.assertIn("### Conditional Resources / Runtime Support", text)
+        self.assertIn("Do not preload every resource", text)
+        self.assertIn("Portable alias: `resources/primitives/`", text)
+        for filename in USING_MINDTHUS_CONDITIONAL_PRIMITIVES:
+            self.assertIn(f"docs/methodologies/primitives/{filename}", text)
+        self.assertIn("resources/fidelity-contract.md", text)
 
     def test_using_mindthus_entrypoint_has_no_empty_markdown_headings(self):
         path = REPO / "skills" / "using-mindthus" / "SKILL.md"
@@ -713,6 +757,20 @@ class PackagingDocsTests(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assert_release_pack_excludes_runtime_artifacts(out)
+
+            for skill_dir in (
+                out / "claude-code" / "claude-plugin" / "skills" / "using-mindthus",
+                out / "claude-code" / "skills" / "using-mindthus",
+                out / "codex-plugin" / "mindthus" / "skills" / "using-mindthus",
+                out / "codex" / "skills" / "mindthus" / "using-mindthus",
+                out
+                / "opencode"
+                / ".opencode"
+                / "skills"
+                / "mindthus"
+                / "using-mindthus",
+            ):
+                self.assert_packaged_using_mindthus_primitives(skill_dir)
 
             marketplace_path = out / "claude-code" / ".claude-plugin" / "marketplace.json"
             plugin_path = out / "claude-code" / "claude-plugin" / ".claude-plugin" / "plugin.json"

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -8,18 +8,23 @@ REPO = Path(__file__).resolve().parents[1]
 
 class ReleaseBoundaryContractTests(unittest.TestCase):
     def test_current_release_log_does_not_record_exact_suite_count(self):
-        release_log = (REPO / "docs" / "releases" / "v1.4.3.md").read_text(
+        release_log = (REPO / "docs" / "releases" / "v1.4.5.md").read_text(
             encoding="utf-8"
         )
         self.assertIsNone(re.search(r"\b\d+\s+tests\s+OK\b", release_log))
 
-    def test_current_release_surface_is_v1_4_3(self):
+    def test_current_release_surface_is_v1_4_5(self):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
         builder = (REPO / "scripts" / "build-release-pack.py").read_text(encoding="utf-8")
+        runtime_logger = (REPO / "scripts" / "log-mindthus-runtime.py").read_text(
+            encoding="utf-8"
+        )
 
-        self.assertIn("当前仓库版本：`v1.4.3`", readme)
+        self.assertIn("当前仓库版本：`v1.4.5`", readme)
         self.assertEqual(readme.count("当前仓库版本："), 1)
+        self.assertNotIn("当前仓库版本：`v1.4.4`", readme)
+        self.assertNotIn("当前仓库版本：`v1.4.3`", readme)
         self.assertNotIn("当前仓库版本：`v1.4.2`", readme)
         self.assertNotIn("当前仓库版本：`v1.4.1`", readme)
         self.assertNotIn("## 版本与开发状态", readme)
@@ -29,65 +34,87 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         self.assertIn("输入定框审计", readme)
         self.assertIn("framing-risk", readme)
         self.assertIn("用户价值、偏好、审美和风险姿态", readme)
-        self.assertIn("mindthus-plugins-1.4.3.tar.gz", readme)
-        self.assertIn("mindthus-skills-1.4.3.tar.gz", readme)
+        self.assertIn("mindthus-plugins-1.4.5.tar.gz", readme)
+        self.assertIn("mindthus-skills-1.4.5.tar.gz", readme)
         self.assertIn(
-            "github.com/rv198-star/Mindthus/releases/download/v1.4.3/mindthus-plugins-1.4.3.tar.gz",
+            "github.com/rv198-star/Mindthus/releases/download/v1.4.5/mindthus-plugins-1.4.5.tar.gz",
             readme,
         )
         self.assertIn(
-            "github.com/rv198-star/Mindthus/releases/download/v1.4.3/mindthus-skills-1.4.3.tar.gz",
+            "github.com/rv198-star/Mindthus/releases/download/v1.4.5/mindthus-skills-1.4.5.tar.gz",
             readme,
         )
         self.assertIn("codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin", readme)
         self.assertIn("claude plugin marketplace add /tmp/mindthus-plugins/claude-code", readme)
         self.assertIn("cp -R /tmp/mindthus-skills/opencode/.opencode", readme)
-        self.assertIn("## v1.4.3", changelog)
-        self.assertIn("[完整发布日志](docs/releases/v1.4.3.md)", changelog)
-        self.assertIn("Method Reference Boundary", changelog)
-        self.assertIn("MPG-AQM 会话取证负测", changelog)
-        self.assertIn("TVG 外部审查边界", changelog)
-        self.assertIn("v1.4.2 GitHub Release 已撤回", changelog)
-        self.assertIn("Compact Semantic Triad / 三根硬支柱", changelog)
-        self.assertIn("Decision Context Calibration / 决策语境校准", changelog)
-        self.assertIn("Aspect Ownership Matrix / 切面主导权矩阵", changelog)
-        self.assertIn("MPG Scalar Commitment Unpack / MPG 标量承诺显影", changelog)
-        self.assertIn('VERSION = "1.4.3"', builder)
+        self.assertIn("## v1.4.5", changelog)
+        self.assertIn("[完整发布日志](docs/releases/v1.4.5.md)", changelog)
+        self.assertIn("显式调用", changelog)
+        self.assertIn("best-effort", changelog)
+        self.assertIn("7,193 bytes", changelog)
+        self.assertIn("1.447 < 1.5", changelog)
+        self.assertIn("不构成自动唤起认证", changelog)
+        self.assertIn('VERSION = "1.4.5"', builder)
+        self.assertIn('VERSION = "1.4.5"', runtime_logger)
 
-        release_log = (REPO / "docs" / "releases" / "v1.4.3.md").read_text(
+        release_log = (REPO / "docs" / "releases" / "v1.4.5.md").read_text(
             encoding="utf-8"
         )
         for phrase in (
+            "# Mindthus v1.4.5 发布日志",
+            "发布日期：2026-07-13",
+            "## 版本定位",
+            "可靠性与产品合同 patch release",
+            "## 主要变化",
+            "显式调用 `using-mindthus` 或具体 skill 是可靠主路径",
+            "host 自动唤起是 best-effort",
+            "7,193 bytes / 900 words",
+            "frame-risk AND execution impact",
+            "routing_decision",
+            "SKILLS 本质是提示词",
+            "4K/5K 显示器争论",
+            "公共方法与 runtime 分离",
+            "#101",
+            "五种布局",
+            "1.447 < 1.5",
+            "v1.4.4-diag",
+            "register-hints",
+            "semantic triage",
+            "不进入 v1.4.5 产品承诺",
+            "SHA256SUMS",
+            "## 升级影响",
+            "## 验证",
+            "python3 scripts/build-release-pack.py",
+            "python3 -m unittest discover",
+        ):
+            self.assertIn(phrase, release_log)
+
+        self.assertNotIn("Release date:", release_log)
+
+    def test_v1_4_3_release_surface_is_preserved(self):
+        changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
+        release_log = (REPO / "docs" / "releases" / "v1.4.3.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("## v1.4.3", changelog)
+        self.assertIn("[完整发布日志](docs/releases/v1.4.3.md)", changelog)
+        for phrase in (
             "# Mindthus v1.4.3 发布日志",
             "发布日期：2026-07-06",
-            "## 版本定位",
-            "## 吸收自 v1.4.2 的内容",
-            "## 主要变化",
-            "## 边界",
-            "## 验证",
             "v1.4.2 GitHub Release 已删除",
             "Compact Semantic Triad / 三根硬支柱",
             "Contrastive Consequence Probe / 后果对比探针",
             "Decision Context Calibration / 决策语境校准",
             "Aspect Ownership Matrix / 切面主导权矩阵",
             "MPG Scalar Commitment Unpack / MPG 标量承诺显影",
-            "docs/methodologies/primitives/",
-            "scripts/primitives/whole_elephant_validator.py",
             "Method Reference Boundary / 方法引用边界",
-            "method name in an inspection request is evidence scope, not route ownership",
-            "019f359a-6aa2-78c0-9ac5-822abae99495",
             "TVG 外部审查防回归",
-            "skills/mpg/SKILL.md",
-            "不要从 v1.4.2 安装或引用其 release asset",
             "本版不关闭 #85",
             "本版不新增独立 skill",
             "不声称解决所有 discovery 层误触",
-            "python3 scripts/build-release-pack.py",
-            "python3 -m pytest -q",
         ):
             self.assertIn(phrase, release_log)
-
-        self.assertNotIn("Release date:", release_log)
 
     def test_v1_1_2_release_surface_is_preserved(self):
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")

--- a/tests/test_v0_9_acceptance.py
+++ b/tests/test_v0_9_acceptance.py
@@ -26,7 +26,7 @@ class V09AcceptanceTests(unittest.TestCase):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
 
-        for phrase in ("当前仓库版本：`v1.4.3`", "GitHub Releases"):
+        for phrase in ("当前仓库版本：`v1.4.5`", "GitHub Releases"):
             self.assertIn(phrase, readme)
 
         for phrase in (

--- a/tests/test_v1_0_1_usage_log.py
+++ b/tests/test_v1_0_1_usage_log.py
@@ -239,7 +239,7 @@ class V101UsageLogTests(unittest.TestCase):
         )
 
         for phrase in (
-            "当前仓库版本：`v1.4.3`",
+            "当前仓库版本：`v1.4.5`",
             "scripts/log-fidelity-usage.py",
             "data/fidelity-usage-log.jsonl",
             "可选：记录使用效果",
@@ -269,7 +269,7 @@ class V101UsageLogTests(unittest.TestCase):
                     / "plugin.json"
                 ).read_text(encoding="utf-8")
             )
-            self.assertEqual(plugin["version"], "1.4.3")
+            self.assertEqual(plugin["version"], "1.4.5")
             for platform_root in (
                 root / "claude-code" / "claude-plugin",
                 root / "codex",

--- a/tests/test_v1_0_readiness.py
+++ b/tests/test_v1_0_readiness.py
@@ -130,7 +130,7 @@ class V10ReadinessTests(unittest.TestCase):
         self.assertIn("closed-source commercial use requires a separate commercial license", readme)
         self.assertIn("SPDX `AGPL-3.0-only`", readme)
         self.assertIn("rather than encoded in the SPDX field", readme)
-        self.assertIn("当前仓库版本：`v1.4.3`", readme)
+        self.assertIn("当前仓库版本：`v1.4.5`", readme)
         self.assertNotIn("Pre-1.0", readme)
 
     def test_release_pack_carries_license_judge_script_and_rubric(self):

--- a/tests/test_v3_audit_optimization_contract.py
+++ b/tests/test_v3_audit_optimization_contract.py
@@ -27,7 +27,7 @@ class V3AuditOptimizationContractTests(unittest.TestCase):
         text = read("skills/using-mindthus/SKILL.md")
         for phrase in (
             "Entry Triage / 入口分诊",
-            "semantic families in shared-primitives",
+            "semantic-family index",
             "not keywords",
         ):
             self.assertIn(phrase, text)


### PR DESCRIPTION
## Summary

- compact the high-frequency `using-mindthus` preload entry while preserving seven detailed primitives in public methodology resources
- make explicit invocation the primary product contract and automatic activation best-effort
- prepare the v1.4.5 changelog, release notes, package/runtime versions, and release-boundary tests

## Evidence boundary

- preserves `v1.4.4-diag` as a diagnostic-only historical tag
- does not claim benchmark certification; the public score remains `1.447 < 1.5`
- excludes abandoned semantic-triage and matcher experiments from the production promise

## Validation

- `python3 -m unittest discover -s tests -p "test_*.py" -q` (`596` tests)
- plugin and skills release packs built and independently audited
- entrypoint remains exactly 900 Python-split words and is mirrored across all five release layouts
- final tarballs and `SHA256SUMS` will be generated from the merged tag commit and verified by fresh download before release completion