### PR TITLE
Release Mindthus v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## Unreleased
 
+## v1.5.0
+
+发布日期：2026-07-19
+
+[完整发布日志](docs/releases/v1.5.0.md)
+
+说明：这是 1.x Stable 线的功能增量版本。它把 TPlan 的真实执行/成本树和 TVG 的
+Profile 保真视觉图谱工作流带入正式发布，但不改变 `using-mindthus` 的可靠调用边界，
+也不发布仍在探索中的 2.x ROI.2 Beta。
+
+### TPlan 真实执行与成本树
+
+- 新 Mission 使用追加式 `execution_trace.jsonl` 记录生命周期和脱敏成本事件；它不替代
+  `evidence.jsonl`，也不保存 prompt、response 或原始 transcript。
+- 新增 host-boundary model observer、traced command 和 sanitized span ingestion，明确区分
+  `host_measured`、`platform_reported`、`inferred` 与不可得测量。
+- 新增 `compact`、`standard`、`audit` 三种执行树视图；完整拓扑、局部 trace、旧 Mission
+  snapshot 都有显式覆盖状态，未知成本保持未知。
+
+### TVG Profile 保真视觉图谱
+
+- 将通用影视画面导演控制收敛为 canonical `cinematic-visual-direction` Profile，并把
+  巨物压迫规则降为可选 `colossal-pressure` 场景适配器；旧路径继续作为兼容入口。
+- 新增 Profile 保真的 `9 -> 3 -> 9` 图谱探索、稳定 `Rnn-Eyy` 标识、可见 lineage、
+  evidence hash、search freeze、delivery audit 与 finalization evidence。
+- 图谱脚本只标注、拼板和校验确定性事实；审美选择和退出判断仍由 agent / 用户负责。
+
+### 发布边界
+
+- 显式调用 `using-mindthus` 或具体 skill 仍是可靠主路径；host 自然唤起仍是 best-effort。
+- issue #109 的可复现实验进入仓库测试证据，但 tests、内部设计、benchmark 与运行记录不进入 release pack。
+- ROI.2 仅确认为 2.x Beta 演进线；本版不创建 2.x tag、Release 或安装资产。
+
+### 验证
+
+- `python3 -m unittest discover -s tests -p 'test_*.py' -q`
+- `python3 scripts/build-release-pack.py --package plugins --out /tmp/mindthus-release-plugins-check --force`
+- `python3 scripts/build-release-pack.py --package skills --out /tmp/mindthus-release-skills-check --force`
+
 ## v1.4.6
 
 发布日期：2026-07-14

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Host 根据自然语言自行发现并唤起 Mindthus 属于 **best-effort** 能
 
 优先安装插件包；插件不可用或需要 portable skills 时，再安装 skills 包。
 
-- Codex App / Codex CLI / Claude Code 支持插件：下载 `mindthus-plugins-1.4.6.tar.gz`。
-- 不使用插件、需要 OpenCode、或只想复制 skills 目录：下载 `mindthus-skills-1.4.6.tar.gz`。
+- Codex App / Codex CLI / Claude Code 支持插件：下载 `mindthus-plugins-1.5.0.tar.gz`。
+- 不使用插件、需要 OpenCode、或只想复制 skills 目录：下载 `mindthus-skills-1.5.0.tar.gz`。
 
 不要在同一个 client profile 里同时安装 plugin mode 和 skills-pack mode，除非你正在测试重复 discovery。
 
@@ -110,29 +110,29 @@ Host 根据自然语言自行发现并唤起 Mindthus 属于 **best-effort** 能
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-plugins-1.4.6.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.4.6/mindthus-plugins-1.4.6.tar.gz"
+  -o /tmp/mindthus-plugins-1.5.0.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.5.0/mindthus-plugins-1.5.0.tar.gz"
 rm -rf /tmp/mindthus-plugins
 mkdir -p /tmp/mindthus-plugins
-tar -xzf /tmp/mindthus-plugins-1.4.6.tar.gz -C /tmp/mindthus-plugins --strip-components=1
+tar -xzf /tmp/mindthus-plugins-1.5.0.tar.gz -C /tmp/mindthus-plugins --strip-components=1
 ```
 
 Skills 包，供 Codex skills-pack / Claude Code personal skills / OpenCode 使用：
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-skills-1.4.6.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.4.6/mindthus-skills-1.4.6.tar.gz"
+  -o /tmp/mindthus-skills-1.5.0.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.5.0/mindthus-skills-1.5.0.tar.gz"
 rm -rf /tmp/mindthus-skills
 mkdir -p /tmp/mindthus-skills
-tar -xzf /tmp/mindthus-skills-1.4.6.tar.gz -C /tmp/mindthus-skills --strip-components=1
+tar -xzf /tmp/mindthus-skills-1.5.0.tar.gz -C /tmp/mindthus-skills --strip-components=1
 ```
 
 ### Codex Plugin Mode（推荐）
 
 ```bash
 codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin
-codex plugin list --marketplace mindthus --available
+codex plugin list --marketplace mindthus --available --json
 codex plugin add mindthus@mindthus
 codex plugin list
 ```
@@ -249,7 +249,7 @@ python3 scripts/log-fidelity-usage.py --help
 
 ## 版本与许可
 
-当前仓库版本：`v1.4.6`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
+当前仓库版本：`v1.5.0`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
 
 Mindthus uses AGPLv3 + commercial dual licensing.
 

--- a/docs/releases/v1.5.0.md
+++ b/docs/releases/v1.5.0.md
@@ -1,0 +1,125 @@
+# Mindthus v1.5.0 发布日志
+
+发布日期：2026-07-19
+
+## 版本定位
+
+`v1.5.0` 是 1.x Stable 线的功能增量版本。它正式交付两组已经在 main 收敛并具备合同测试的能力：
+
+1. TPlan 对 Mission 实际执行路径、时间和 Token 边界的可复查记录与执行成本树；
+2. TVG 在不稀释已选 Profile 的前提下进行视觉方案图谱探索、筛选和交付审计。
+
+这不是 2.x 路由架构的发布。ROI.2 仍是独立的 2.x Beta 演进线；本版不携带其候选 runtime，
+不创建 2.x tag 或 Release，也不把 Beta 资格证据重签为 Stable 证据。
+
+## TPlan：实际执行与成本树
+
+新建 Mission 现在会得到追加式 `execution_trace.jsonl` 和只读 `reports/` 目录。通过 TPlan
+runtime script 发生的 Mission 初始化、节点增加、active node 切换和状态迁移会写入生命周期
+事件；host 或平台可以另外写入脱敏的 model、agent turn、script、tool、wait 与 runtime span。
+
+这条 trace 的用途是回答“实际跑了什么、顺序如何、观察到多少成本”，不是证明结论正确：
+
+- `execution_trace.jsonl` 不替代 `evidence.jsonl`；
+- 不记录 prompt、response、命令参数、stdout、stderr 或原始 transcript；
+- 缺失时间或 Token 保持缺失，不用零或源码字数补齐；
+- `cached_input_tokens` 是 input 子集，不重复计入总量；
+- `host_measured` 只表示调用方看到的请求耗时，不冒充 provider 内部纯推理时间；
+- shared、mission overhead 和 unattributed span 不按猜测拆给某个 Task。
+
+新增 runtime support 包括：
+
+- `observe_model_call.py`：在 host-owned SDK 边界记录成对 model span；
+- `record_execution_span.py`：接收平台提供的脱敏时间和 usage；
+- `run_traced_command.py`：测量 script / tool 的 caller-visible elapsed；
+- `render_execution_cost_tree.py`：生成 `compact`、`standard` 或 `audit` 视图。
+
+`standard` 和 `audit` 保留每个真实 Mission / Task / SubTask / Step 及声明边；`compact` 是有明确
+省略规则的文本投影，不伪造 display group。旧 Mission 没有 trace 时显示 `snapshot_only`，中途开始
+记录时显示 `partial`，不会把不完整测量包装成完整历史。
+
+## TVG：Profile 保真视觉图谱
+
+原 `cinematic-colossal-realism` 把通用影视导演控制和巨物压力场景规则绑在一起，容易让一个
+高质量局部案例静默变成通用 Profile 的定义。v1.5.0 将它拆成主从两层：
+
+- canonical `cinematic-visual-direction`：负责镜头、构图、光线、空间、材质、运动和第一读；
+- `colossal-pressure` scene adapter：只在巨物压迫场景中叠加尺度锚点、环境反馈与局部威胁规则；
+- `cinematic-colossal-realism`：保留为 v1.4.6 历史路径和兼容入口。
+
+新的视觉图谱支持 Profile 保真的 `9 -> 3 -> 9` 探索：稳定 `Rnn-Eyy` 标识、父子 lineage、
+Profile / prompt / image evidence hash、selection board、`search-freeze`、delivery audit 和
+finalization evidence 都有明确合同。脚本只负责可重复的标注、拼板和结构校验；它们不能判断
+哪张图更好、Profile 是否成熟、是否值得继续，最终审美仍由用户拥有。
+
+图谱 trace 校验只依赖 Python 标准库；图像标注和 selection board 拼接可选使用
+`Pillow>=10,<13`。这不是所有 Mindthus 用户的新增必选依赖。
+
+## 稳定线收敛与证据边界
+
+- #121 的 TPlan execution-cost-tree 实现及其本地/CI 验证进入 Stable。
+- #120 的 Profile-preserving atlas 实现及 TVG 合同验证进入 Stable；#79 的视觉 Profile 工作已被 main 包含。
+- #110 为已关闭研究 #109 增加可复现实验输入、预期结果和测试；这些开发证据保留在仓库，
+  但 tests 和研究材料不进入公开安装包。
+- 旧 PR #46 被 main 上更新的 Entry Triage、Whole Elephant、Decision Context 和负向控制合同取代，
+  不把冲突的旧实现重新合入。
+- #67 是低优先级 CLI 探索；其旧候选 PR #80 存在 artifact 内命令目标缺失、版本失真和
+  安装合同未验证等 Stable 阻断，已关闭而未合并。#112 是 2.x Beta 母题；两个 issue 继续保留，
+  不构成 1.5 阻断。
+
+## 继承的产品边界
+
+- 显式调用 `using-mindthus` 或具体 skill 是可靠主路径；host 自然唤起仍是 best-effort。
+- `using-mindthus`、七个 owner 和条件认知原语保持 1.x Stable 合同；本版不引入模型名分流。
+- TPlan telemetry 是观察面，不是新的 Judge、Evaluator 或语义正确性证明。
+- TVG atlas 是有界视觉产物工作流，不把确定性脚本提升为审美控制器。
+- release pack 不包含 `docs/internal/`、`docs/superpowers/`、tests、logs、benchmark、Mission runtime 或本地路径。
+- ROI.2 implementation、qualification 和后续 convergence commit 不进入本版安装资产；不发布 Beta2.X。
+
+## 安装
+
+plugin mode 适用于 Codex App / CLI 与 Claude Code：
+
+```bash
+VERSION=1.5.0
+curl -L \
+  -o /tmp/mindthus-plugins-${VERSION}.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-plugins-${VERSION}.tar.gz"
+```
+
+skills-pack mode 适用于 OpenCode 或手动复制 skills：
+
+```bash
+VERSION=1.5.0
+curl -L \
+  -o /tmp/mindthus-skills-${VERSION}.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v${VERSION}/mindthus-skills-${VERSION}.tar.gz"
+```
+
+最终 Release 资产同时提供 `SHA256SUMS`，由两个 tarball 生成后单独计算。
+
+## 升级影响
+
+- 无破坏性 schema migration；Mission 主 schema 仍为 `tplan.v0.1`。
+- execution trace 是新增的 `tplan.execution_trace.v0.1` sidecar。
+- 旧 Mission 可继续使用，并以 `snapshot_only` 或 `partial` 显示实际覆盖范围。
+- 无新增全局必选依赖；只有使用 atlas 图像拼板脚本时才需要 Pillow。
+- 已安装用户可直接用 v1.5.0 覆盖旧 plugin / skills 包。
+- 依赖自动 discovery 的工作流仍应把它视为 best-effort；关键判断请显式调用。
+
+## 验证
+
+```bash
+python3 -m unittest discover -s tests -p 'test_*.py' -q
+python3 scripts/build-release-pack.py --package plugins --out /tmp/mindthus-release-plugins-check --force
+python3 scripts/build-release-pack.py --package skills --out /tmp/mindthus-release-skills-check --force
+```
+
+发布前核对：
+
+- plugin release pack 内的 Codex / Claude manifest 和 runtime logger 均为 `1.5.0`；
+- TPlan trace scripts、execution tree renderer 和合同资源进入 skills 与 plugin pack；
+- `cinematic-visual-direction`、兼容入口、scene adapter、atlas contract 和 scripts 进入两种 pack；
+- release pack 不含 tests、logs、内部研究文档、benchmark、Beta runtime 或 Mission 运行产物；
+- 隔离安装 v1.5.0 后可回滚到 v1.4.6，且不接触用户现有 CODEX_HOME；
+- 构建资产的 SHA-256 与 GitHub Release 上传后下载结果一致。

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -9,7 +9,7 @@ import shutil
 from pathlib import Path
 
 
-VERSION = "1.4.6"
+VERSION = "1.5.0"
 EXCLUDED_DIRS = {
     "__pycache__",
     ".pytest_cache",

--- a/scripts/log-mindthus-runtime.py
+++ b/scripts/log-mindthus-runtime.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 
-VERSION = "1.4.6"
+VERSION = "1.5.0"
 RELATIVE_FILES = (
     "skills/using-mindthus/SKILL.md",
     "skills/using-mindthus/resources/calibration-pairs.yaml",

--- a/tests/test_log_mindthus_runtime.py
+++ b/tests/test_log_mindthus_runtime.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "log-mindthus-runtime.py"
-CURRENT_VERSION = "1.4.6"
+CURRENT_VERSION = "1.5.0"
 
 
 USING_TEXT = """\

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -90,7 +90,7 @@ class PackagingDocsTests(unittest.TestCase):
         for phrase in (
             "mindthus:tplan",
             "mindthus:*",
-            "当前仓库版本：`v1.4.6`",
+            "当前仓库版本：`v1.5.0`",
             "局部正确",
             "输入定框审计",
             "framing-risk",
@@ -580,6 +580,8 @@ class PackagingDocsTests(unittest.TestCase):
         self.assertIn("Skills 包，供 Codex skills-pack / Claude Code personal skills / OpenCode 使用", readme)
         self.assertIn("Codex Plugin Mode（推荐）", readme)
         self.assertIn("codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin", readme)
+        self.assertIn("codex plugin list --marketplace mindthus --available --json", readme)
+        self.assertNotIn("codex plugin list --marketplace mindthus --available\n", readme)
         self.assertIn("codex plugin add mindthus@mindthus", readme)
         self.assertIn("Claude Code Plugin Mode（推荐）", readme)
         self.assertIn("claude plugin marketplace add /tmp/mindthus-plugins/claude-code", readme)
@@ -779,7 +781,7 @@ class PackagingDocsTests(unittest.TestCase):
             source = marketplace["plugins"][0]["source"]
             self.assertEqual(source, "./claude-plugin")
             self.assertNotIn("..", source)
-            self.assertEqual(plugin["version"], "1.4.6")
+            self.assertEqual(plugin["version"], "1.5.0")
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "tplan" / "SKILL.md").exists())
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "mpg" / "SKILL.md").exists())
             claude_hook_config_path = out / "claude-code" / "claude-plugin" / "hooks" / "hooks.json"
@@ -867,7 +869,7 @@ class PackagingDocsTests(unittest.TestCase):
             )
             self.assertEqual(codex_marketplace["plugins"][0]["policy"]["installation"], "AVAILABLE")
             self.assertEqual(codex_plugin_manifest["name"], "mindthus")
-            self.assertEqual(codex_plugin_manifest["version"], "1.4.6")
+            self.assertEqual(codex_plugin_manifest["version"], "1.5.0")
             self.assertEqual(codex_plugin_manifest["skills"], "./skills/")
             self.assertEqual(codex_plugin_manifest["license"], "AGPL-3.0-only")
             self.assertEqual(codex_plugin_manifest["interface"]["brandColor"], "#161614")
@@ -1002,8 +1004,8 @@ class PackagingDocsTests(unittest.TestCase):
         script = REPO / "scripts" / "build-release-pack.py"
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            plugins = tmp_dir / "mindthus-plugins-1.4.6"
-            skills = tmp_dir / "mindthus-skills-1.4.6"
+            plugins = tmp_dir / "mindthus-plugins-1.5.0"
+            skills = tmp_dir / "mindthus-skills-1.5.0"
 
             plugin_result = subprocess.run(
                 ["python3", str(script), "--package", "plugins", "--out", str(plugins)],

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -8,12 +8,12 @@ REPO = Path(__file__).resolve().parents[1]
 
 class ReleaseBoundaryContractTests(unittest.TestCase):
     def test_current_release_log_does_not_record_exact_suite_count(self):
-        release_log = (REPO / "docs" / "releases" / "v1.4.6.md").read_text(
+        release_log = (REPO / "docs" / "releases" / "v1.5.0.md").read_text(
             encoding="utf-8"
         )
         self.assertIsNone(re.search(r"\b\d+\s+tests\s+OK\b", release_log))
 
-    def test_current_release_surface_is_v1_4_6(self):
+    def test_current_release_surface_is_v1_5_0(self):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
         builder = (REPO / "scripts" / "build-release-pack.py").read_text(encoding="utf-8")
@@ -21,8 +21,9 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
             encoding="utf-8"
         )
 
-        self.assertIn("当前仓库版本：`v1.4.6`", readme)
+        self.assertIn("当前仓库版本：`v1.5.0`", readme)
         self.assertEqual(readme.count("当前仓库版本："), 1)
+        self.assertNotIn("当前仓库版本：`v1.4.6`", readme)
         self.assertNotIn("当前仓库版本：`v1.4.4`", readme)
         self.assertNotIn("当前仓库版本：`v1.4.3`", readme)
         self.assertNotIn("当前仓库版本：`v1.4.2`", readme)
@@ -34,41 +35,82 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         self.assertIn("输入定框审计", readme)
         self.assertIn("framing-risk", readme)
         self.assertIn("用户价值、偏好、审美和风险姿态", readme)
-        self.assertIn("mindthus-plugins-1.4.6.tar.gz", readme)
-        self.assertIn("mindthus-skills-1.4.6.tar.gz", readme)
+        self.assertIn("mindthus-plugins-1.5.0.tar.gz", readme)
+        self.assertIn("mindthus-skills-1.5.0.tar.gz", readme)
         self.assertIn(
-            "github.com/rv198-star/Mindthus/releases/download/v1.4.6/mindthus-plugins-1.4.6.tar.gz",
+            "github.com/rv198-star/Mindthus/releases/download/v1.5.0/mindthus-plugins-1.5.0.tar.gz",
             readme,
         )
         self.assertIn(
-            "github.com/rv198-star/Mindthus/releases/download/v1.4.6/mindthus-skills-1.4.6.tar.gz",
+            "github.com/rv198-star/Mindthus/releases/download/v1.5.0/mindthus-skills-1.5.0.tar.gz",
             readme,
         )
         self.assertIn("codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin", readme)
+        self.assertIn("codex plugin list --marketplace mindthus --available --json", readme)
+        self.assertNotIn("codex plugin list --marketplace mindthus --available\n", readme)
         self.assertIn("claude plugin marketplace add /tmp/mindthus-plugins/claude-code", readme)
         self.assertIn("cp -R /tmp/mindthus-skills/opencode/.opencode", readme)
-        self.assertIn("## v1.4.6", changelog)
-        self.assertIn("[完整发布日志](docs/releases/v1.4.6.md)", changelog)
+        self.assertIn("## v1.5.0", changelog)
+        self.assertIn("[完整发布日志](docs/releases/v1.5.0.md)", changelog)
         self.assertIn("显式调用", changelog)
         self.assertIn("best-effort", changelog)
-        self.assertIn("7,193 bytes", changelog)
-        self.assertIn("1.447 < 1.5", changelog)
-        self.assertIn("不构成自动唤起认证", changelog)
-        self.assertIn('VERSION = "1.4.6"', builder)
-        self.assertIn('VERSION = "1.4.6"', runtime_logger)
+        self.assertIn("execution_trace.jsonl", changelog)
+        self.assertIn("9 -> 3 -> 9", changelog)
+        self.assertIn("ROI.2", changelog)
+        self.assertIn('VERSION = "1.5.0"', builder)
+        self.assertIn('VERSION = "1.5.0"', runtime_logger)
 
-        release_log = (REPO / "docs" / "releases" / "v1.4.6.md").read_text(
+        release_log = (REPO / "docs" / "releases" / "v1.5.0.md").read_text(
             encoding="utf-8"
         )
         for phrase in (
+            "# Mindthus v1.5.0 发布日志",
+            "发布日期：2026-07-19",
+            "## 版本定位",
+            "## TPlan：实际执行与成本树",
+            "execution_trace.jsonl",
+            "host_measured",
+            "snapshot_only",
+            "render_execution_cost_tree.py",
+            "## TVG：Profile 保真视觉图谱",
+            "cinematic-visual-direction",
+            "colossal-pressure",
+            "9 -> 3 -> 9",
+            "Rnn-Eyy",
+            "Pillow>=10,<13",
+            "## 稳定线收敛与证据边界",
+            "#121",
+            "#120",
+            "#110",
+            "#67",
+            "#80",
+            "#112",
+            "ROI.2",
+            "不发布 Beta2.X",
+            "SHA256SUMS",
+            "## 升级影响",
+            "## 验证",
+            "python3 scripts/build-release-pack.py",
+            "python3 -m unittest discover",
+        ):
+            self.assertIn(phrase, release_log)
+
+        self.assertNotIn("Release date:", release_log)
+
+    def test_v1_4_6_release_surface_is_preserved(self):
+        changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
+        release_log = (REPO / "docs" / "releases" / "v1.4.6.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("## v1.4.6", changelog)
+        self.assertIn("[完整发布日志](docs/releases/v1.4.6.md)", changelog)
+        for phrase in (
             "# Mindthus v1.4.6 发布日志",
             "发布日期：2026-07-14",
-            "## 版本定位",
             "TVG-Profile",
             "cinematic-colossal-realism",
             "四层高级包",
-            "电影级图像 prompt packet",
-            "不是两个风格化画面的并列示范",
             "## Codex 插件图标主题适配",
             "logoDark",
             "mindthus-icon.svg",
@@ -76,12 +118,7 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
             "v1.4.4-diag",
             "register-hints",
             "semantic triage",
-            "不进入本版产品承诺",
             "SHA256SUMS",
-            "## 升级影响",
-            "## 验证",
-            "python3 scripts/build-release-pack.py",
-            "python3 -m unittest discover",
         ):
             self.assertIn(phrase, release_log)
 

--- a/tests/test_v0_9_acceptance.py
+++ b/tests/test_v0_9_acceptance.py
@@ -26,7 +26,7 @@ class V09AcceptanceTests(unittest.TestCase):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
 
-        for phrase in ("当前仓库版本：`v1.4.6`", "GitHub Releases"):
+        for phrase in ("当前仓库版本：`v1.5.0`", "GitHub Releases"):
             self.assertIn(phrase, readme)
 
         for phrase in (

--- a/tests/test_v1_0_1_usage_log.py
+++ b/tests/test_v1_0_1_usage_log.py
@@ -239,7 +239,7 @@ class V101UsageLogTests(unittest.TestCase):
         )
 
         for phrase in (
-            "当前仓库版本：`v1.4.6`",
+            "当前仓库版本：`v1.5.0`",
             "scripts/log-fidelity-usage.py",
             "data/fidelity-usage-log.jsonl",
             "可选：记录使用效果",
@@ -269,7 +269,7 @@ class V101UsageLogTests(unittest.TestCase):
                     / "plugin.json"
                 ).read_text(encoding="utf-8")
             )
-            self.assertEqual(plugin["version"], "1.4.6")
+            self.assertEqual(plugin["version"], "1.5.0")
             for platform_root in (
                 root / "claude-code" / "claude-plugin",
                 root / "codex",

--- a/tests/test_v1_0_readiness.py
+++ b/tests/test_v1_0_readiness.py
@@ -130,7 +130,7 @@ class V10ReadinessTests(unittest.TestCase):
         self.assertIn("closed-source commercial use requires a separate commercial license", readme)
         self.assertIn("SPDX `AGPL-3.0-only`", readme)
         self.assertIn("rather than encoded in the SPDX field", readme)
-        self.assertIn("当前仓库版本：`v1.4.6`", readme)
+        self.assertIn("当前仓库版本：`v1.5.0`", readme)
         self.assertNotIn("Pre-1.0", readme)
 
     def test_release_pack_carries_license_judge_script_and_rubric(self):


### PR DESCRIPTION
## Summary

- publish the 1.x Stable increment for TPlan execution/cost telemetry and TVG Profile-preserving visual atlas workflow
- bump generated plugin/runtime surfaces and README install assets to 1.5.0
- add v1.5.0 changelog and full Chinese release notes
- correct the current Codex CLI discovery command to require `--available --json`
- keep ROI.2 as an unpublished 2.x Beta line; no Beta runtime, tag, or Release is included

## Stable convergence

- #121, #120, #110, and the already-landed #79 work are represented in main
- stale/superseded PRs #46 and #80 were audited and closed rather than mechanically merged
- #67 remains a low-priority architecture exploration; #112 remains the 2.x Beta parent

## Verification

- `python3 -m unittest discover -s tests -p 'test_*.py' -q` — pass (637 run, 2 skipped)
- plugins and skills release packs build successfully
- 886 packaged files audited: no forbidden paths, symlinks, local absolute paths, secret-pattern hits, or ROI.2/Beta runtime hits
- all five platform layouts contain the new TPlan and TVG runtime surfaces
- packaged TPlan trace/render smoke and TVG atlas trace validation pass
- isolated Codex plugin install reports 1.5.0; rollback to the verified v1.4.6 release reports 1.4.6
- existing user CODEX_HOME was not modified

## Release boundary

This PR prepares Stable only. It does not publish, merge, tag, or re-sign any 2.x Beta candidate or qualification evidence.
