### PR TITLE
fix: repair Stable prerelease readiness contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ Host 根据自然语言自行发现并唤起 Mindthus 属于 **best-effort** 能
 
 优先安装插件包；插件不可用或需要 portable skills 时，再安装 skills 包。
 
-- Codex App / Codex CLI / Claude Code 支持插件：下载 `mindthus-plugins-1.5.1.tar.gz`。
-- 不使用插件、需要 OpenCode、或只想复制 skills 目录：下载 `mindthus-skills-1.5.1.tar.gz`。
+当前已发布 Stable 是 `v1.4.6`；仓库中的 `v1.5.1` 仍是尚未发布的修复候选。
+
+- Codex App / Codex CLI / Claude Code 支持插件：下载 `mindthus-plugins-1.4.6.tar.gz`。
+- 不使用插件、需要 OpenCode、或只想复制 skills 目录：下载 `mindthus-skills-1.4.6.tar.gz`。
 
 不要在同一个 client profile 里同时安装 plugin mode 和 skills-pack mode，除非你正在测试重复 discovery。
 
@@ -110,22 +112,22 @@ Host 根据自然语言自行发现并唤起 Mindthus 属于 **best-effort** 能
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-plugins-1.5.1.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.5.1/mindthus-plugins-1.5.1.tar.gz"
+  -o /tmp/mindthus-plugins-1.4.6.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.4.6/mindthus-plugins-1.4.6.tar.gz"
 rm -rf /tmp/mindthus-plugins
 mkdir -p /tmp/mindthus-plugins
-tar -xzf /tmp/mindthus-plugins-1.5.1.tar.gz -C /tmp/mindthus-plugins --strip-components=1
+tar -xzf /tmp/mindthus-plugins-1.4.6.tar.gz -C /tmp/mindthus-plugins --strip-components=1
 ```
 
 Skills 包，供 Codex skills-pack / Claude Code personal skills / OpenCode 使用：
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-skills-1.5.1.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.5.1/mindthus-skills-1.5.1.tar.gz"
+  -o /tmp/mindthus-skills-1.4.6.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.4.6/mindthus-skills-1.4.6.tar.gz"
 rm -rf /tmp/mindthus-skills
 mkdir -p /tmp/mindthus-skills
-tar -xzf /tmp/mindthus-skills-1.5.1.tar.gz -C /tmp/mindthus-skills --strip-components=1
+tar -xzf /tmp/mindthus-skills-1.4.6.tar.gz -C /tmp/mindthus-skills --strip-components=1
 ```
 
 ### Codex Plugin Mode（推荐）

--- a/docs/releases/v1.5.1.md
+++ b/docs/releases/v1.5.1.md
@@ -55,4 +55,4 @@ python3 scripts/build-release-pack.py --package skills --out /tmp/mindthus-1.5.1
 - 本步骤不创建 `v1.5.1` tag。
 - 本步骤不创建 GitHub Release，不上传 tarball。
 - 本步骤不合并 2.x Beta，不准备 Beta release。
-- README 中的 v1.5.1 下载路径属于发布候选表面；只有后续明确授权发布并上传资产后才会生效。
+- README 在正式授权发布前继续指向现有 `v1.4.6` Stable 资产，不暴露尚不存在的 v1.5.1 下载路径。

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -60,8 +60,8 @@ CLAUDE_ACTIVATION_ROUTER_PROMPT = (
     "brainstorming and should intervene only at remaining hard judgment points."
 )
 CODEX_ACTIVATION_ROUTER_PROMPT = (
-    "Mindthus: hard frame/whole/binary/spiral/no-data -> mindthus:using-mindthus; "
-    "method-ref review direct; direct; evidence 1st; defer Superpowers."
+    "Mindthus: frame/whole/binary/spiral/no-data -> mindthus:using-mindthus; "
+    "method-ref direct; evidence 1st; defer Superpowers."
 )
 
 

--- a/scripts/log-mindthus-runtime.py
+++ b/scripts/log-mindthus-runtime.py
@@ -7,12 +7,15 @@ import argparse
 import hashlib
 import json
 import os
+import tomllib
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence
 
 
 VERSION = "1.5.1"
+PACKAGE_IDENTITY = "mindthus"
+MARKETPLACE_IDENTITY = "mindthus"
 RELATIVE_FILES = (
     "skills/using-mindthus/SKILL.md",
     "skills/using-mindthus/resources/calibration-pairs.yaml",
@@ -52,8 +55,6 @@ REQUIRED_MARKERS = (
     "在回答前，先执行“输入审计”，不要顺着我的叙述直接推理",
     "Truth Orientation / 真相优先",
     "pursue facts and truth over agreement",
-    "user input is signal, constraint, or hypothesis; not evidence by itself",
-    "First task: judge whether the user led you to the wrong level",
     "audit order: true_question -> implicit_premises -> local_validity_and_layer_shift -> reframed_question -> formal_answer",
     "Entry Triage / 入口分诊",
     "definition authority contest",
@@ -81,10 +82,7 @@ REQUIRED_MARKERS = (
     "definition_owner",
     "result_controller",
     "decision_consequence",
-    "validate_whole_elephant.py",
-    "scripts/primitives/validate_whole_elephant.py",
     "mindthus-whole-elephant-audit-v0.1",
-    "validation failure blocks formal answer",
     "When Partial Truth Capture triggers, the formal answer is incomplete without",
     "target job",
     "main use cases",
@@ -108,7 +106,6 @@ REQUIRED_MARKERS = (
     "Explanatory Authority Check / 解释权校准",
     "Dominant Carrier Check / 主导承载校准",
     "System Subject Check / 系统主体校准",
-    "local correctness is not explanatory authority",
     "problem key over dialogue continuity",
     "professional tone is not proof",
     "common implementation is not essence",
@@ -128,8 +125,35 @@ def default_marketplace_root(codex_home: Path) -> Path:
     return codex_home / "local-marketplaces" / f"mindthus-v{VERSION}" / "codex-plugin" / "mindthus"
 
 
+def configured_marketplace_root(codex_home: Path) -> Path:
+    fallback = default_marketplace_root(codex_home)
+    config_path = codex_home / "config.toml"
+    if not config_path.is_file():
+        return fallback
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        marketplace = config["marketplaces"][MARKETPLACE_IDENTITY]
+        if marketplace.get("source_type") != "local":
+            return fallback
+        source_root = Path(marketplace["source"]).expanduser().resolve()
+        manifest = json.loads(
+            (source_root / ".agents" / "plugins" / "marketplace.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        plugin = next(
+            item for item in manifest["plugins"] if item.get("name") == PACKAGE_IDENTITY
+        )
+        plugin_source = plugin["source"]
+        if plugin_source.get("source") != "local":
+            return fallback
+        return (source_root / plugin_source["path"]).resolve()
+    except (KeyError, StopIteration, OSError, tomllib.TOMLDecodeError, TypeError, ValueError):
+        return fallback
+
+
 def default_cache_root(codex_home: Path) -> Path:
-    return codex_home / "plugins" / "cache" / "mindthus" / "mindthus" / VERSION
+    return codex_home / "plugins" / "cache" / MARKETPLACE_IDENTITY / PACKAGE_IDENTITY / VERSION
 
 
 def sha256_text(path: Path) -> str:
@@ -307,7 +331,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     args.codex_home = Path(args.codex_home).expanduser()
     if args.marketplace_root is None:
-        args.marketplace_root = default_marketplace_root(args.codex_home)
+        args.marketplace_root = configured_marketplace_root(args.codex_home)
     else:
         args.marketplace_root = Path(args.marketplace_root).expanduser()
     if args.cache_root is None:

--- a/tests/test_log_mindthus_runtime.py
+++ b/tests/test_log_mindthus_runtime.py
@@ -271,6 +271,41 @@ class LogMindthusRuntimeTests(unittest.TestCase):
         self.assertEqual(args.cache_root, cache_root)
         self.assertEqual(args.marketplace_root, marketplace_root)
 
+    def test_parse_args_discovers_local_marketplace_from_codex_config(self):
+        logger = load_runtime_logger()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            codex_home = root / "home"
+            marketplace = root / "marketplace"
+            plugin = marketplace / "mindthus"
+            (marketplace / ".agents" / "plugins").mkdir(parents=True)
+            plugin.mkdir()
+            (marketplace / ".agents" / "plugins" / "marketplace.json").write_text(
+                json.dumps(
+                    {
+                        "name": "mindthus",
+                        "plugins": [
+                            {
+                                "name": "mindthus",
+                                "source": {"source": "local", "path": "./mindthus"},
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            codex_home.mkdir()
+            (codex_home / "config.toml").write_text(
+                "[marketplaces.mindthus]\n"
+                "source_type = \"local\"\n"
+                f"source = {json.dumps(str(marketplace))}\n",
+                encoding="utf-8",
+            )
+
+            args = logger.parse_args(["--codex-home", str(codex_home)])
+
+            self.assertEqual(args.marketplace_root, plugin.resolve())
+
     def test_reports_matching_runtime_fingerprints_and_markers_as_json(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -306,7 +341,6 @@ class LogMindthusRuntimeTests(unittest.TestCase):
             self.assertTrue(payload["summary"]["all_available_hashes_match"])
             self.assertIn("Truth Orientation / 真相优先", payload["markers"])
             self.assertIn("pursue facts and truth over agreement", payload["markers"])
-            self.assertIn("First task: judge whether the user led you to the wrong level", payload["markers"])
             self.assertIn("Entry Triage / 入口分诊", payload["markers"])
             self.assertIn("definition authority contest", payload["markers"])
             self.assertIn("green tests imply release readiness", payload["markers"])
@@ -338,13 +372,11 @@ class LogMindthusRuntimeTests(unittest.TestCase):
             self.assertIn("definition_owner", payload["markers"])
             self.assertIn("result_controller", payload["markers"])
             self.assertIn("decision_consequence", payload["markers"])
-            self.assertIn("validate_whole_elephant.py", payload["markers"])
             self.assertIn(
                 "When Partial Truth Capture triggers, the formal answer is incomplete without",
                 payload["markers"],
             )
             self.assertIn("mindthus-whole-elephant-audit-v0.1", payload["markers"])
-            self.assertIn("validation failure blocks formal answer", payload["markers"])
             self.assertIn(
                 "scripts/primitives/validate_whole_elephant.py",
                 payload["locations"]["cache"]["files"],

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -48,6 +48,71 @@ def parse_frontmatter_mapping(text: str) -> dict[str, str]:
 
 
 class PackagingDocsTests(unittest.TestCase):
+    def test_generated_plugin_runtime_diagnostic_accepts_healthy_local_install(self):
+        script = REPO / "scripts" / "build-release-pack.py"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out = root / "release"
+            codex_home = root / "home"
+            cache = codex_home / "plugins" / "cache" / "mindthus" / "mindthus" / "1.5.1"
+            result = subprocess.run(
+                [sys.executable, str(script), "--package", "plugins", "--out", str(out)],
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            shutil.copytree(out / "codex-plugin" / "mindthus", cache)
+            codex_home.mkdir(exist_ok=True)
+            (codex_home / "config.toml").write_text(
+                "[marketplaces.mindthus]\n"
+                "source_type = \"local\"\n"
+                f"source = {json.dumps(str(out / 'codex-plugin'))}\n",
+                encoding="utf-8",
+            )
+            diagnostic = subprocess.run(
+                [
+                    sys.executable,
+                    str(cache / "scripts" / "log-mindthus-runtime.py"),
+                    "--codex-home",
+                    str(codex_home),
+                    "--json",
+                    "--strict",
+                ],
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(diagnostic.returncode, 0, diagnostic.stderr)
+            payload = json.loads(diagnostic.stdout)
+            self.assertEqual(payload["summary"]["status"], "ok")
+            self.assertEqual(
+                Path(payload["locations"]["marketplace"]["root"]),
+                (out / "codex-plugin" / "mindthus").resolve(),
+            )
+
+    def test_release_pack_rejects_repository_and_nested_output_paths(self):
+        script = REPO / "scripts" / "build-release-pack.py"
+        for output in (REPO, REPO / "release-inside-repository"):
+            with self.subTest(output=str(output)):
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(script),
+                        "--package",
+                        "plugins",
+                        "--out",
+                        str(output),
+                        "--force",
+                    ],
+                    text=True,
+                    capture_output=True,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "refusing output directory inside protected source tree",
+                    result.stderr + result.stdout,
+                )
+        self.assertFalse((REPO / "release-inside-repository").exists())
+
     @unittest.skipUnless(importlib.util.find_spec("PIL") is not None, "Pillow is required")
     def test_generated_plugin_runs_documented_atlas_label_and_selection_stages(self):
         from PIL import Image
@@ -1103,16 +1168,16 @@ class PackagingDocsTests(unittest.TestCase):
             self.assertEqual(
                 codex_plugin_manifest["interface"]["defaultPrompt"],
                 [
-                    "Mindthus: hard frame/whole/binary/spiral/no-data -> mindthus:using-mindthus; "
-                    "method-ref review direct; direct; evidence 1st; defer Superpowers."
+                    "Mindthus: frame/whole/binary/spiral/no-data -> mindthus:using-mindthus; "
+                    "method-ref direct; evidence 1st; defer Superpowers."
                 ],
             )
             codex_default_prompt = codex_plugin_manifest["interface"]["defaultPrompt"][0]
             self.assertIn("Superpowers", codex_default_prompt)
-            self.assertIn("method-ref review direct", codex_default_prompt)
-            self.assertIn("hard frame/whole/binary/spiral/no-data", codex_default_prompt)
-            self.assertLessEqual(len(codex_default_prompt), 192)
-            self.assertLessEqual(len(codex_default_prompt.encode("utf-8")), 192)
+            self.assertIn("method-ref direct", codex_default_prompt)
+            self.assertIn("frame/whole/binary/spiral/no-data", codex_default_prompt)
+            self.assertLessEqual(len(codex_default_prompt), 123)
+            self.assertLessEqual(len(codex_default_prompt.encode("utf-8")), 123)
             self.assertNotIn("v3", codex_default_prompt.lower())
             self.assertTrue((codex_plugin_root / "skills" / "tplan" / "SKILL.md").exists())
             self.assertTrue((codex_plugin_root / "skills" / "mpg" / "SKILL.md").exists())

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -35,14 +35,17 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         self.assertIn("输入定框审计", readme)
         self.assertIn("framing-risk", readme)
         self.assertIn("用户价值、偏好、审美和风险姿态", readme)
-        self.assertIn("mindthus-plugins-1.5.1.tar.gz", readme)
-        self.assertIn("mindthus-skills-1.5.1.tar.gz", readme)
+        self.assertIn("当前已发布 Stable 是 `v1.4.6`", readme)
+        self.assertIn("mindthus-plugins-1.4.6.tar.gz", readme)
+        self.assertIn("mindthus-skills-1.4.6.tar.gz", readme)
+        self.assertNotIn("mindthus-plugins-1.5.1.tar.gz", readme)
+        self.assertNotIn("mindthus-skills-1.5.1.tar.gz", readme)
         self.assertIn(
-            "github.com/rv198-star/Mindthus/releases/download/v1.5.1/mindthus-plugins-1.5.1.tar.gz",
+            "github.com/rv198-star/Mindthus/releases/download/v1.4.6/mindthus-plugins-1.4.6.tar.gz",
             readme,
         )
         self.assertIn(
-            "github.com/rv198-star/Mindthus/releases/download/v1.5.1/mindthus-skills-1.5.1.tar.gz",
+            "github.com/rv198-star/Mindthus/releases/download/v1.4.6/mindthus-skills-1.4.6.tar.gz",
             readme,
         )
         self.assertIn("codex plugin marketplace add /tmp/mindthus-plugins/codex-plugin", readme)


### PR DESCRIPTION
## Summary
- keep README downloads on published v1.4.6 while 1.5.1 remains unpublished
- reduce Codex defaultPrompt to 123 bytes so Beta namespace remains within the proven 128-byte loader limit
- discover actual local marketplace roots from isolated CODEX_HOME config
- remove stale diagnostic markers and test a real generated plugin health report
- preserve and regress repository output-path safety

## Verification
- full local suite: 656 tests OK
- generated Stable plugin reports diagnostics status=ok from actual local marketplace/cache coordinates

GitHub CI remains unavailable due to cost controls. This changes source readiness only; it does not publish 1.5.1.