### PR TITLE
feat(WAE): add Ownership Closure mode

### DIFF
--- a/docs/methodologies/wae.md
+++ b/docs/methodologies/wae.md
@@ -31,6 +31,7 @@ WAE 解决的是控制权错位。
 - 日志很多，但没有可用于决策的 evidence。
 - 工作流看起来很规范，但出错后没人知道该回退、停下还是继续。
 - 新增规则越来越多，却没有说明它们控制的是 workflow、agent 还是 evidence。
+- 名义上已经由 Agentic owner 负责的工作继续委托后，下游 helper / adapter 仍然需要决定会改变结果的语义。
 
 这些场景都默认发生在 agentic 系统里。普通概念分类、组织责任、产品边界、
 结构 A/B 判断或流程治理问题，不会因为出现“边界 / 责任 / 流程 / 证据”这些词
@@ -53,6 +54,63 @@ WAE 的核心判断是三分法：
 
 路径确定、语义确定的工作交给 workflow。路径不确定或语义不确定的工作保留 agentic judgment。凡是会影响结论、验收、继续/停止或用户信任的 claim，都需要 evidence 约束。
 
+## 第二层：Ownership Closure / 所有权闭合
+
+多数 WAE 判断做到上面的控制分配就够了。但复杂 agentic system 里还有一种失败：
+**第一层 Owner 分对了，语义却在委托链里继续往下泄漏。**
+
+例如：
+
+```text
+Agentic service owns persistence
+    -> Repository.save(record)
+    -> StorageAdapter.persist(record)
+```
+
+如果 `StorageAdapter` 仍然必须自己决定 `insert / update / append`、冲突是拒绝还是覆盖、哪些字段写入、失败或返回语义是什么，那么“Agentic owns persistence”只是名义上的第一层答案。真正改变结果的语义选择仍没有被显式 owner 掌握。
+
+WAE 把这种情况称为 `Semantic Ownership Leakage / 语义所有权泄漏`。这时才进入条件性的 `Ownership Closure / 所有权闭合`：沿着**可能携带语义选择的 delegation boundary**继续检查，而不是沿代码层级无限递归。
+
+核心原则：
+
+> Ownership must extend to the last non-mechanical decision point.
+>
+> Ownership follows semantic choice; Workflow follows deterministic consequence.
+
+检查时问：下游是否仍需要理解业务/领域语义、从多个合理结果中选择、解释 prose/隐含上下文，或者决定会改变状态、副作用、权限、失败语义和最终结果的行为？如果是，边界没有闭合，应把该选择交给明确 semantic owner，或把它显式化为结构化 contract。
+
+### Mechanical Boundary / 机械边界
+
+递归不是越深越好。一旦剩余工作同时满足这些条件，就必须停止：
+
+- 输入完整且结构化；
+- 对允许的输入，行为唯一确定；
+- 不再需要业务或领域判断；
+- 剩余验证与执行可以机械完成；
+- 未知或不完整输入会 fail closed，而不是靠 heuristic 猜语义。
+
+例如 Agentic 已明确给出：
+
+```yaml
+kind: append
+conflict: reject
+return_fields:
+  - id
+  - created_at
+```
+
+后续 schema validation、parameterized SQL、transaction、row mapping 可以很复杂，但如果行为已经由该 contract 唯一决定，它们仍然属于 Workflow / mechanical execution。
+
+所以 Ownership 追随的是**语义选择**，不是 implementation depth。
+
+### Evidence 可以重开边界，但普通失败不行
+
+Ownership Closure 不是 `fix -> test -> fix` 的泛化 Loop。
+
+如果真实 runtime evidence 表明某个下游组件仍不知道该选哪种业务行为，它可以推翻此前“边界已经闭合”的判断，让 WAE 重新细化 ownership。
+
+但如果语义已经完整，只是 SQL placeholder 写错、格式转换有 bug、timeout 或其他机械实现失败，这只是 execution repair。Owner 和 semantic contract 没变，就不属于 Ownership Refinement。
+
 ## 怎么用
 
 轻量 WAE 不需要复杂表格，先问三句：
@@ -69,6 +127,8 @@ WAE 的核心判断是三分法：
 
 如果边界仍然不清，再使用 worksheet 或更完整的控制边界分析。WAE 的目标是减少控制混乱，不是给每个任务增加一层流程。
 
+只有在已经分配 semantic owner 后仍出现 delegation smell、下游多种合理行为、heuristic 语义推断，或 runtime evidence 暴露隐藏 semantic choice 时，才继续做 Ownership Closure。普通 WAE case 不需要多跑这一层。
+
 ## 具体案例
 
 ### 案例 A：CI 能不能判断文档质量
@@ -83,19 +143,27 @@ CI 可以检查 README 是否存在、链接是否有效、方法页是否包含
 
 WAE 会要求把关键 claim 单独接到 evidence 上。例如“安装说明有效”需要脚本语法检查或实际安装结果；“文档更易懂”至少需要具体改动、示例覆盖和 reviewer 反馈，而不是“我已经优化过”。
 
-## 常见误用
+### 案例 C：Repository 已经 Agentic owns，为什么还没闭合
 
-第一种误用，是把 WAE 当通用流程设计器。WAE 只处理 agentic 系统里的控制权，
-不负责把所有工作流程化。
+一个 Agentic service 正确拥有 persistence intent，但把一个只有 domain object 的 `save(record)` 交给 generic adapter。adapter 仍要决定追加还是更新、冲突策略和返回行为。
+
+这不是“再跑一次 WAE”或“多做一次测试”能解决的问题，而是当前 ownership contract 没有延伸到最后一个 semantic choice。正确修复是先把这些选择显式化，例如形成完整 `PersistenceCommand`，再把确定性的 SQL/execution 留给 Workflow。
+
+## 常见误用
 
 第零种误用，是把 WAE 当成所有边界问题的默认方法。没有 agentic system，
 不要用 WAE；没有 controller mismatch，也不要用 WAE。
+
+第一种误用，是把 WAE 当通用流程设计器。WAE 只处理 agentic 系统里的控制权，
+不负责把所有工作流程化。
 
 第二种误用，是把 evidence 做成字段。字段存在不代表证据有效；证据必须能约束具体 claim。
 
 第三种误用，是让脚本代替判断。脚本可以验证 shape、状态和确定性规则，但不能判断“这个文档是否真正有价值”“这个策略是否方向正确”。
 
 第四种误用，是把 agentic judgment 无限扩大。凡是确定、可重复、低风险的工作，都应该尽量交给 workflow，避免 agent 在机械环节消耗注意力。
+
+第五种误用，是把 Ownership Closure 当通用 Agent Loop。只有 Evidence 暴露新的 semantic remainder 时才移动 ownership boundary；普通 implementation retry、测试修复或执行重试不会自动触发 refinement。
 
 ## 边界
 
@@ -105,14 +173,24 @@ WAE 也不负责定义问题本身。如果还不知道问题是什么，用 `3L
 
 当 evidence 不足时，WAE 不会替你补事实。它只会指出“这个 claim 还没有被约束”，然后要求补证据、降级结论或停止。
 
+Ownership Closure 也不是长任务 runtime：它不建立 Mission、任务树、checkpoint、recovery state 或持久化 refinement history。它只判断语义 ownership 是否已经闭合。
+
 ## 与其他方法的关系
 
 - `3L5S` 处理问题发现与落地，WAE 处理其中的控制边界。
 - `SELA` 给长期方向，WAE 判断方向落地时哪些步骤能自动化、哪些必须保留判断。
-- `tplan` 是 WAE 的典型落地场景：状态由脚本控制，语义判断由 agent 完成，关键 claim 由 evidence 约束。
+- `tplan` 是 WAE 的典型落地和承载场景：TPlan 管 Mission/task state、顺序、blocker、checkpoint、recovery 和 resumption；WAE 管 semantic control boundary，以及在必要时判断 ownership 是否闭合。长 Mission 可以反复调用 WAE，但这种 recurrence 由 TPlan 承载，不会把 WAE 变成第二套 runtime。
 - `Anti-Spiral` 可以被理解为 WAE 的失败保护：当 agentic 判断开始用局部修补替代证据进展时，必须刹车。
+
+一句话区分：
+
+```text
+TPlan：下一步发生什么、什么状态要继续？
+WAE：这个语义决定由谁拥有、这个 ownership 是否已经闭合？
+```
 
 ## 导航
 
 - 返回 [README](../../README.md)
 - 查看 [WAE skill](../../skills/wae/SKILL.md)
+- 深入 [Ownership Closure resource](../../skills/wae/resources/ownership-closure.md)

--- a/skills/wae/SKILL.md
+++ b/skills/wae/SKILL.md
@@ -19,6 +19,11 @@ Domain scope: LLMs, agents, skills, prompts, scripts, schemas, workflows, review
 
 > Who or what should control this part of the work?
 
+When a semantic owner delegates work and the boundary may still hide a result-changing
+choice, WAE may ask one conditional second question:
+
+> Is that ownership closed through the delegation, or did semantic choice leak downstream?
+
 Domain Gate: the object must be an LLM / agent / skill / workflow / script / schema /
 evidence-gate system. No agentic system, no WAE.
 
@@ -31,6 +36,7 @@ It is not a generic workflow designer, and it is not a four-quadrant form to fil
 - agentic loops drift without evidence or exit criteria
 - evidence exists but does not constrain claims
 - schemas make judgment look complete while the real uncertainty remains unresolved
+- a nominal semantic owner delegates a result-changing choice to a generic downstream component
 
 ## Mainline / 主路径
 
@@ -77,6 +83,48 @@ Use this only when the Minimal WAE Check is insufficient.
 4. Add evidence bridges where claims need proof or confidence caps.
 5. Apply risk modulators before giving the agentic core more freedom.
 
+### Ownership Closure Mode / 所有权闭合
+
+Ownership Closure is a conditional extension after a semantic control assignment, not a
+default extra ceremony. Use it only when delegation may hide another semantic decision.
+
+Trigger signals include:
+
+- a semantic owner delegates to a repository, adapter, helper, generator, template,
+  mapper, or other generic component;
+- the delegate still has multiple reasonable result-changing behaviors;
+- the delegate must interpret prose, names, field shapes, heuristics, or hidden context;
+- runtime Evidence shows that end-to-end behavior is not determined by the declared
+  owner's contract;
+- a supposedly mechanical layer must invent semantics for unknown input.
+
+When triggered:
+
+1. Name the current semantic owner and the result-changing choices it should own.
+2. Inspect only delegations that may carry those choices downstream.
+3. If a delegate still needs semantic/domain judgment or must choose among multiple
+   reasonable result-changing outcomes, diagnose `Semantic Ownership Leakage`.
+4. Refine the owner or structured contract until the semantic choice is explicit, then
+   re-evaluate the next relevant boundary.
+5. Stop at the `Mechanical Boundary`: complete structured input determines admitted
+   behavior uniquely, no domain judgment remains, mechanical validation is sufficient,
+   and unknown/underspecified input fails closed.
+
+Core rule:
+
+> Ownership follows semantic choice; Workflow follows deterministic consequence.
+
+Ownership follows semantic choice, not implementation depth. A difficult or deeply
+nested executor can remain Workflow-controlled after semantics are complete.
+
+Evidence may reopen a previous closure judgment when it reveals a missing
+result-changing choice. A syntax error, malformed transform, timeout, or other defect in
+implementing an already-complete choice is execution repair, not Ownership Boundary
+Refinement.
+
+Read `resources/ownership-closure.md` for the detailed closure test, evidence-feedback
+rules, WAE/TPlan boundary, anti-loop guardrails, and frozen acceptance cases.
+
 ## Guardrails / 从属补漏
 
 ### Risk Modulators / 风险调制
@@ -107,6 +155,8 @@ Scripts may enforce order, deterministic transforms, mechanical checks, and stat
 
 Scripts must not decide high-uncertainty truth, erase meaningful ambiguity, or replace judgment with field completion.
 
+Ownership Closure must not become a generic `act -> test -> fix` loop, a recursive code-depth inspection, or a reason to move deterministic work back into Agentic control.
+
 If a WAE output becomes cleaner but thinner, treat that as a regression.
 
 ### Worksheet
@@ -120,6 +170,9 @@ The worksheet is an aid for judgment, not evidence that the judgment is correct.
 - WAE answers control-boundary questions; it is not a generic workflow designer.
 - WAE is scoped to agentic-system control boundaries; it is not the default method for
   ordinary boundary, responsibility, process, or evidence questions.
+- Ownership Closure is a WAE semantic-boundary judgment, not Mission/task runtime. TPlan
+  continues to own long-running state, ordering, blockers, checkpoints, recovery, and
+  resumption.
 - Do not use WAE to slow down low-risk formatting or deterministic work.
 - Do not let worksheet completion, schema shape, or clean structure replace judgment.
 - Do not treat human escalation as a routine fourth control layer.
@@ -128,6 +181,7 @@ The worksheet is an aid for judgment, not evidence that the judgment is correct.
 
 Read `resources/methodology.md` when you need quadrants, risk modulators, runtime governance, boundary questions, hard rules, anti-patterns, or the practical decision table.
 
+- `resources/ownership-closure.md` — conditional Ownership Closure semantics, Mechanical Boundary stopping test, Evidence feedback, and WAE/TPlan boundary.
 - `resources/fidelity-contract.md` — WAE fidelity contract for v0.9.
 - `templates/fidelity-output.json` — example v0.9 fidelity output shape.
 - `scripts/validate_wae_output.py` — validate fidelity contract output shape with the shared core.

--- a/skills/wae/resources/ownership-closure.md
+++ b/skills/wae/resources/ownership-closure.md
@@ -1,0 +1,223 @@
+# WAE Ownership Closure
+
+Layer: `mainline extension` with guardrails and boundaries
+Issue: #149
+
+## Core / 核心
+
+WAE normally answers:
+
+> Who or what should control this part of the work?
+
+Ownership Closure adds a conditional second question:
+
+> Does the chosen semantic owner still own every result-changing semantic choice after delegation?
+
+The target invariant is:
+
+> Ownership must extend to the last non-mechanical decision point.
+
+The governing rule is:
+
+> Ownership follows semantic choice; Workflow follows deterministic consequence.
+
+`Ownership Closure` is the target state. `Ownership Boundary Refinement` is the
+mechanism used when the current boundary is not closed. `Recursive Ownership
+Refinement` may describe that mechanism, but it is not a separate Mindthus method.
+
+## Mainline / 主路径
+
+Do not run this mode after every WAE decision. Enter it only when the initial control
+assignment may hide another semantic boundary.
+
+### Trigger signals
+
+Use Ownership Closure when one or more of these are true:
+
+- a declared semantic owner delegates to a repository, adapter, helper, generator,
+  template, mapper, policy shell, or other generic downstream component;
+- the downstream component still has multiple reasonable result-changing behaviors;
+- the downstream component must interpret prose, names, field shapes, heuristics, or
+  hidden context to choose behavior;
+- runtime evidence shows that an apparently complete owner cannot determine end-to-end
+  behavior without a downstream semantic decision;
+- a supposedly mechanical layer must invent behavior for unknown or underspecified
+  input.
+
+A useful smell is:
+
+```text
+semantic owner
+    -> generic helper(...)
+```
+
+The smell is not itself proof of leakage. Inspect whether the helper still owns a
+semantic choice.
+
+### Closure flow
+
+1. **Name the current semantic owner.** State the result-changing choices that owner is
+   supposed to control.
+2. **Inspect the delegation boundary.** Look only at delegations that may carry those
+   choices downstream; do not recursively inspect implementation depth for its own sake.
+3. **Test the semantic remainder.** Ask whether the delegate still needs domain meaning,
+   trade-off judgment, contextual interpretation, or a choice among multiple reasonable
+   outcomes that changes state, permission, side effects, failure semantics, or the
+   final result.
+4. **Refine when needed.** If such a choice remains, the boundary is not closed. Diagnose
+   `Semantic Ownership Leakage`, move the choice to an explicit semantic owner or make
+   it explicit in a structured contract, then re-evaluate the next delegation boundary.
+5. **Stop at the Mechanical Boundary.** Once the remaining behavior is uniquely
+   derivable from complete structured input and unknown input fails closed, stop
+   refinement and keep the remainder mechanical/Workflow-controlled.
+
+This is boundary convergence, not task decomposition. The analysis may revisit WAE as
+new evidence appears, but it does not create a generic execution loop.
+
+## Semantic Ownership Leakage
+
+`Semantic Ownership Leakage` means:
+
+> A nominal semantic owner delegates work while a downstream component still has to
+> make a result-changing semantic choice that the declared ownership contract did not
+> resolve.
+
+Typical examples include a persistence adapter still choosing insert/update/append or
+conflict policy; an API mapper choosing fallback semantics; a UI generator choosing
+information priority or recovery behavior; or an integration helper choosing retry,
+fallback, degradation, or partial-success policy.
+
+The technology layer is not what makes these Agentic. The remaining semantic choice is.
+
+Do not diagnose leakage merely because implementation is complex. A complicated SQL
+builder, transaction engine, renderer, or protocol stack can remain mechanical when its
+input already determines behavior uniquely.
+
+## Mechanical Boundary / 停止条件
+
+Ownership Boundary Refinement must stop when the remaining work satisfies all of these:
+
+1. **Complete structured input** — every result-changing admitted choice needed by the
+   downstream executor is represented explicitly.
+2. **Unique admitted behavior** — for admitted inputs, the intended output or action is
+   mechanically determined rather than selected from several reasonable meanings.
+3. **No domain judgment remains** — the executor does not need business interpretation,
+   contextual trade-offs, or natural-language inference.
+4. **Mechanical validation is sufficient** — shape, legality, references, deterministic
+   transforms, execution, and observable results can be checked without deciding domain
+   truth.
+5. **Unknown input fails closed** — unsupported or underspecified input is rejected or
+   surfaced; it is not converted into a semantic guess.
+
+This is a WAE-local stopping test. It does not authorize a new schema, validator,
+runtime gate, or persistent state machine.
+
+Ownership follows semantic choice, **not implementation depth**.
+
+## Evidence Feedback
+
+Evidence has two roles in Closure work:
+
+- prove or constrain claims about the realized behavior;
+- reveal that the previous ownership granularity was wrong.
+
+A green unit test, typecheck, or mocked integration can support an implementation claim
+without proving Ownership Closure. If real runtime evidence later reveals that a
+downstream component cannot choose behavior without inventing semantics, WAE may reopen
+the closure judgment and refine the boundary.
+
+Reopening requires evidence of a **semantic remainder**, not merely an execution defect.
+A syntax error, malformed placeholder, timeout, or other repairable mechanical failure
+does not change ownership when the intended behavior was already fully specified.
+
+## Guardrails / 防止误用
+
+### Not a generic loop
+
+Do not call every `act -> test -> fix -> retest` sequence Ownership Boundary
+Refinement. Retry changes execution; Closure changes the semantic ownership boundary.
+
+A useful discrimination question is:
+
+> Did the evidence reveal a missing result-changing choice, or only a defective
+> implementation of an already-complete choice?
+
+Only the first can reopen Ownership Closure.
+
+### Not unlimited Agentic expansion
+
+Do not move deterministic work into Agentic control because it is difficult, deeply
+nested, domain-specific in syntax, or implemented in many layers. Stop as soon as the
+Mechanical Boundary test passes.
+
+### Evidence is feedback, not WAE state
+
+Ownership Closure does not require a WAE ledger, checkpoint history, task tree, or
+persistent refinement state. Evidence may be supplied by the surrounding work and may
+change the WAE judgment without becoming a new WAE runtime.
+
+## Boundary with TPlan
+
+WAE Ownership Closure and TPlan can recur together, but they own different things.
+
+- **WAE** decides who owns a result-changing semantic choice and whether that ownership
+  boundary is closed.
+- **TPlan** owns long-running Mission/task state, ordering, checkpoints, blockers,
+  recovery, decision hooks, resumption, and lifecycle control.
+
+Inside a TPlan Mission, runtime evidence may cause a task to invoke WAE Closure again.
+TPlan records and schedules the consequence; WAE performs the semantic boundary
+judgment. WAE must not create duplicate Mission state or recovery machinery.
+
+Short distinction:
+
+```text
+TPlan: what happens next, and what state continues?
+WAE:   who owns this semantic decision, and is that boundary closed?
+```
+
+## Worked contrast
+
+### Closure refinement
+
+```text
+Agentic service owns persistence
+    -> Repository.save(record)
+    -> adapter must still choose append vs update and conflict behavior
+```
+
+The adapter still owns unresolved semantic choices. Refine the contract until those
+choices are explicit, for example:
+
+```yaml
+kind: append
+conflict: reject
+return_fields:
+  - id
+  - created_at
+```
+
+If the remaining executor can now validate and execute that command deterministically,
+the Mechanical Boundary has been reached.
+
+### Ordinary repair, not closure refinement
+
+The same complete command reaches an SQL builder that emits a malformed parameter
+placeholder. The implementation is wrong, but the semantic contract is complete.
+Repair and retest without moving the ownership boundary.
+
+## Boundary / 不做什么
+
+Ownership Closure does not:
+
+- create a new top-level Mindthus methodology;
+- replace WAE's Minimal Check or make deep analysis the default;
+- decompose Mission/Task/SubTask/Step structures;
+- own retry scheduling, task recovery, or checkpoints;
+- require persistent WAE state;
+- authorize new governance gates or schemas;
+- treat helper names, architecture layers, or code depth as proof of ownership.
+
+Use the frozen acceptance casebook at
+`tests/wae/ownership_closure_acceptance_cases.md` as the implementation and regression
+reference for this mode.

--- a/tests/test_wae_contract.py
+++ b/tests/test_wae_contract.py
@@ -200,6 +200,7 @@ class WaeContractTests(unittest.TestCase):
 
     def test_skill_exposes_conditional_ownership_closure(self):
         text = (WAE / "SKILL.md").read_text(encoding="utf-8")
+        normalized = " ".join(text.split())
         for phrase in (
             "Ownership Closure Mode",
             "conditional extension after a semantic control assignment",
@@ -209,7 +210,7 @@ class WaeContractTests(unittest.TestCase):
             "not implementation depth",
             "execution repair, not Ownership Boundary Refinement",
         ):
-            self.assertIn(phrase, text)
+            self.assertIn(phrase, normalized)
 
     def test_ownership_closure_resource_defines_stop_and_non_loop_boundaries(self):
         text = CLOSURE.read_text(encoding="utf-8")
@@ -225,8 +226,6 @@ class WaeContractTests(unittest.TestCase):
             "WAE must not create duplicate Mission state or recovery machinery",
         ):
             self.assertIn(phrase, text)
-
-        self.assertNotIn("Mission/Task/SubTask state machine", text)
 
     def test_public_doc_explains_closure_without_turning_wae_into_tplan(self):
         text = WAE_DOC.read_text(encoding="utf-8")

--- a/tests/test_wae_contract.py
+++ b/tests/test_wae_contract.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 WAE = REPO / "skills" / "wae"
+WAE_DOC = REPO / "docs" / "methodologies" / "wae.md"
+CLOSURE = WAE / "resources" / "ownership-closure.md"
+CLOSURE_CASES = REPO / "tests" / "wae" / "ownership_closure_acceptance_cases.md"
 
 
 class WaeContractTests(unittest.TestCase):
@@ -194,6 +197,66 @@ class WaeContractTests(unittest.TestCase):
         for text in (methodology, worksheet):
             self.assertIn("A complete worksheet where every Expanded Field was filled", text)
             self.assertIn("regression signal, not a quality signal", text)
+
+    def test_skill_exposes_conditional_ownership_closure(self):
+        text = (WAE / "SKILL.md").read_text(encoding="utf-8")
+        for phrase in (
+            "Ownership Closure Mode",
+            "conditional extension after a semantic control assignment",
+            "Semantic Ownership Leakage",
+            "Mechanical Boundary",
+            "Ownership follows semantic choice; Workflow follows deterministic consequence",
+            "not implementation depth",
+            "execution repair, not Ownership Boundary Refinement",
+        ):
+            self.assertIn(phrase, text)
+
+    def test_ownership_closure_resource_defines_stop_and_non_loop_boundaries(self):
+        text = CLOSURE.read_text(encoding="utf-8")
+        for phrase in (
+            "Ownership must extend to the last non-mechanical decision point",
+            "Trigger signals",
+            "Semantic Ownership Leakage",
+            "Mechanical Boundary / 停止条件",
+            "Unknown input fails closed",
+            "Not a generic loop",
+            "Evidence is feedback, not WAE state",
+            "Boundary with TPlan",
+            "WAE must not create duplicate Mission state or recovery machinery",
+        ):
+            self.assertIn(phrase, text)
+
+        self.assertNotIn("Mission/Task/SubTask state machine", text)
+
+    def test_public_doc_explains_closure_without_turning_wae_into_tplan(self):
+        text = WAE_DOC.read_text(encoding="utf-8")
+        for phrase in (
+            "Ownership Closure / 所有权闭合",
+            "Semantic Ownership Leakage / 语义所有权泄漏",
+            "Mechanical Boundary / 机械边界",
+            "Ownership 追随的是**语义选择**，不是 implementation depth",
+            "Ownership Closure 不是 `fix -> test -> fix` 的泛化 Loop",
+            "TPlan：下一步发生什么、什么状态要继续？",
+            "WAE：这个语义决定由谁拥有、这个 ownership 是否已经闭合？",
+        ):
+            self.assertIn(phrase, text)
+
+    def test_ownership_closure_acceptance_casebook_is_frozen_and_complete(self):
+        text = CLOSURE_CASES.read_text(encoding="utf-8")
+        for case_id in range(1, 9):
+            self.assertIn(f"OC-{case_id:02d}", text)
+
+        for phrase in (
+            "frozen acceptance design before implementation",
+            "negative control / no escalation",
+            "Semantic Ownership Leakage",
+            "Mechanical Boundary stops refinement",
+            "Execution retry is not Ownership Refinement",
+            "TPlan hosts recurrence but does not own closure semantics",
+            "Unknown mechanical input fails closed",
+            "Freeze rule",
+        ):
+            self.assertIn(phrase, text)
 
 
 if __name__ == "__main__":

--- a/tests/wae/ownership_closure_acceptance_cases.md
+++ b/tests/wae/ownership_closure_acceptance_cases.md
@@ -1,0 +1,436 @@
+# WAE Ownership Closure Acceptance Cases
+
+Issue: #149
+Status: frozen acceptance design before implementation
+Date: 2026-08-09
+
+## Purpose
+
+These cases define the behavioral boundary for adding `Ownership Closure` to WAE.
+They are intentionally frozen before substantive WAE implementation changes so the
+method is evaluated against predeclared failure classes rather than post-hoc examples.
+
+The target upgrade is narrow:
+
+> WAE should not stop at a nominal control assignment when delegated work still
+> contains a result-changing semantic choice.
+
+The target invariant is:
+
+> Ownership must extend to the last non-mechanical decision point.
+
+The stopping principle is:
+
+> Ownership follows semantic choice; Workflow follows deterministic consequence.
+
+These cases do **not** authorize a new top-level methodology, a WAE runtime state
+machine, a TPlan-lite task loop, a new persistent schema, or a new governance gate.
+
+## Evaluation dimensions
+
+A conforming WAE implementation should demonstrate all of the following:
+
+1. `first_order_fidelity` — ordinary WAE cases remain ordinary WAE cases.
+2. `leakage_detection` — hidden semantic choice behind delegation is recognized.
+3. `boundary_refinement` — ownership or the contract is refined until the semantic
+   choice has an explicit owner.
+4. `mechanical_stop` — refinement stops once the remainder is uniquely mechanical.
+5. `evidence_reopen` — runtime evidence may invalidate a previously assumed closure.
+6. `loop_discrimination` — retry/repair is not confused with ownership refinement.
+7. `tplan_separation` — Mission/task runtime remains TPlan responsibility.
+8. `cross_domain_generalization` — the rule is not persistence-specific.
+9. `fail_closed_unknowns` — a mechanical executor does not invent missing semantics.
+
+## Case OC-01 — First-order WAE is sufficient
+
+**Role:** negative control / no escalation
+
+### Situation
+
+An agentic reviewer decides whether a generated release note contains an unsupported
+claim. It reads the source diff and release evidence, decides the claim is unsupported,
+and emits a structured decision:
+
+```yaml
+claim_id: release-runtime-generation
+status: reject
+reason_code: unsupported_by_release_evidence
+```
+
+A deterministic renderer converts that decision into the standard release-review
+format. The renderer has no authority to change `status`, reinterpret `reason_code`,
+or invent an alternative conclusion.
+
+### Expected WAE behavior
+
+- Assign semantic review to `Agentic` and rendering to `Workflow`.
+- Do not enter Ownership Closure refinement merely because there is a downstream
+  renderer/helper.
+- Treat the structured decision as a sufficient semantic handoff because downstream
+  output is uniquely derivable from it.
+
+### Must not happen
+
+- Do not recursively inspect every formatter/template implementation layer.
+- Do not convert deterministic rendering into additional Agentic work.
+- Do not create Mission/task state to prove closure.
+
+### Pass condition
+
+WAE can state why the boundary is already closed and stop at the mechanical handoff.
+
+---
+
+## Case OC-02 — Hidden semantic choice behind a generic storage helper
+
+**Role:** primary positive case / Semantic Ownership Leakage
+
+### Situation
+
+An Agentic service is declared to own persistence semantics for a learning record. It
+constructs a domain object and calls:
+
+```text
+Repository.save(record)
+    -> S3StorageAdapter.persist(record)
+```
+
+The storage adapter has no complete persistence command. To implement `persist`, it
+must still decide among reasonable alternatives:
+
+- `insert`, `update`, or `append`;
+- reject, overwrite, merge, or ignore on conflict;
+- which mutable fields are written;
+- which fields are returned;
+- whether a duplicate is an error, no-op, or idempotent success.
+
+### Expected WAE behavior
+
+- Detect that the nominal Agentic owner did not close the semantic boundary.
+- Diagnose the failure as `Semantic Ownership Leakage`.
+- Refine ownership or the contract until the result-changing choices above are made by
+  an explicit semantic owner.
+- A valid refinement may produce a complete structured command such as:
+
+```yaml
+kind: append
+table: learning_record
+values: ...
+conflict: reject
+return_fields:
+  - id
+  - created_at
+```
+
+### Must not happen
+
+- Do not call the adapter deterministic merely because it has an implementation-shaped
+  name such as `adapter`, `repository`, or `helper`.
+- Do not let the adapter infer conflict policy from field names, prose, conventions, or
+  heuristics while still classifying the boundary as closed.
+- Do not fix the case by adding a retry loop around `persist`.
+
+### Pass condition
+
+Every result-changing persistence choice has a visible semantic owner before the
+mechanical persistence layer begins.
+
+---
+
+## Case OC-03 — Mechanical Boundary stops refinement
+
+**Role:** anti-over-Agentic guard / stopping case
+
+### Situation
+
+The semantic owner produces this complete command:
+
+```yaml
+kind: append
+table: learning_record
+values:
+  learner_id: "L-42"
+  concept_id: "C-7"
+  score: 0.81
+conflict: reject
+return_fields:
+  - id
+  - created_at
+```
+
+The remaining path is:
+
+```text
+schema validation
+-> parameterized SQL generation
+-> transaction execution
+-> row mapping
+-> exit-code/runtime evidence
+```
+
+For the admitted command vocabulary, each step is deterministic and unknown command
+kinds fail closed.
+
+### Expected WAE behavior
+
+- Recognize a `Mechanical Boundary`.
+- Stop Ownership Boundary Refinement.
+- Keep schema validation, SQL generation, execution, row mapping, and mechanical
+  evidence in Workflow/mechanical control.
+
+### Must not happen
+
+- Do not require Agentic reasoning merely because SQL or transactions are complex.
+- Do not recurse down implementation depth after semantic choice has reached zero.
+- Do not ask an agent to second-guess an already complete `conflict: reject` decision.
+
+### Pass condition
+
+WAE explicitly stops because the semantic remainder is zero, not because the code stack
+has ended.
+
+---
+
+## Case OC-04 — Evidence reopens a nominally closed boundary
+
+**Role:** evidence-feedback case
+
+### Situation
+
+A repository implementation passes:
+
+- TypeScript typecheck;
+- build;
+- unit tests;
+- mocked repository tests.
+
+A real PostgreSQL/HTTP runtime test then fails because the final adapter cannot determine
+whether a duplicate learning record should be appended, updated, or rejected. The mock
+had hidden this choice.
+
+### Expected WAE behavior
+
+- Treat the runtime result as evidence that the earlier ownership granularity was wrong.
+- Reopen the closure judgment even though previous evidence was green.
+- Inspect the delegation path and refine the semantic contract/owner.
+- Preserve the distinction between "tests passed" and "ownership was actually closed".
+
+### Must not happen
+
+- Do not dismiss the runtime evidence because prior tests were green.
+- Do not classify this only as an implementation bug when the failure reveals a real
+  multiple-reasonable-path semantic choice.
+- Do not make Evidence a persistent WAE runtime ledger merely to support reopening.
+
+### Pass condition
+
+Evidence can invalidate a prior closure assumption and cause a boundary correction.
+
+---
+
+## Case OC-05 — Execution retry is not Ownership Refinement
+
+**Role:** negative control / loop discrimination
+
+### Situation
+
+A complete persistence command correctly states:
+
+```yaml
+kind: append
+conflict: reject
+```
+
+The SQL builder accidentally emits a malformed parameter placeholder. Integration tests
+fail with a syntax error. No semantic choice is missing: the correct behavior is fully
+specified, and the defect can be repaired mechanically.
+
+### Expected WAE behavior
+
+- Keep the existing ownership boundary.
+- Treat correction/retry as execution repair, not Ownership Boundary Refinement.
+- Enter closure analysis only if new evidence reveals a missing result-changing choice.
+
+### Must not happen
+
+- Do not move SQL syntax repair into Agentic ownership solely because a test failed.
+- Do not describe every `fix -> test -> fix` cycle as recursive ownership refinement.
+- Do not use WAE Closure as a generic reflection loop.
+
+### Pass condition
+
+The implementation can explain: owner unchanged, semantic contract unchanged, only
+mechanical execution was defective.
+
+---
+
+## Case OC-06 — TPlan hosts recurrence but does not own closure semantics
+
+**Role:** WAE/TPlan boundary case
+
+### Situation
+
+A long-running migration Mission is managed by TPlan. It has task state, acceptance
+evidence, blockers, checkpoints, and recovery. During one migration Task, runtime
+evidence shows that a generated migration helper still decides whether a foreign-key
+relationship should `CASCADE`, `RESTRICT`, or `SET NULL`.
+
+### Expected WAE behavior
+
+- WAE determines that this is unresolved semantic ownership and refines the boundary.
+- TPlan continues to own Mission/task state, blocker recording, ordering, checkpoint,
+  recovery, and resumption.
+- TPlan may record WAE's result and schedule the resulting implementation work, but does
+  not decide the semantic ownership rule itself.
+
+### Must not happen
+
+- Do not create a WAE Mission, task tree, checkpoint, or recovery state.
+- Do not move TPlan's runtime lifecycle into WAE.
+- Do not reduce the semantic decision to a TPlan bookkeeping field whose presence is
+  mistaken for correctness.
+
+### Pass condition
+
+The two methods can be composed without duplicated runtime control planes:
+
+```text
+TPlan: when/what state continues
+WAE:   who owns the semantic decision
+```
+
+---
+
+## Case OC-07 — Cross-domain semantic leakage
+
+**Role:** generalization case
+
+### Situation A: API mapping
+
+A mapper receives `UserProfile` and must produce an external provider payload. Exact
+field projection is known, but the downstream mapper still has to decide whether a
+missing legal name should fall back to display name, be omitted, or block the request.
+
+### Situation B: UI generation
+
+A template generator can mechanically render sections, but the generator still decides
+which warning is prominent, which information is hidden by default, and what error
+recovery action is offered.
+
+### Situation C: integration fallback
+
+A provider client can mechanically issue HTTP requests, but a generic integration
+helper still chooses retry count, fallback provider, degradation behavior, and whether
+partial data is acceptable.
+
+### Expected WAE behavior
+
+For each situation:
+
+- Continue refinement while the downstream layer still chooses among multiple
+  reasonable outcomes that change user-visible/system behavior.
+- Stop once those choices are represented in a complete structured contract and the
+  remaining mapping/rendering/call plumbing is deterministic.
+
+### Must not happen
+
+- Do not define Ownership Closure as a persistence-only rule.
+- Do not classify layout, mapping, or provider plumbing as semantic merely because the
+  domain is unfamiliar.
+- Do not classify a helper as mechanical while it interprets prose or heuristics to
+  choose a result-changing policy.
+
+### Pass condition
+
+The same criterion — remaining semantic choice, not technology type — determines
+whether refinement continues.
+
+---
+
+## Case OC-08 — Unknown mechanical input fails closed
+
+**Role:** Mechanical Generation Eligibility / fail-closed case
+
+### Situation
+
+A deterministic persistence executor supports:
+
+```text
+append | replace | delete
+```
+
+It receives:
+
+```yaml
+kind: reconcile
+```
+
+No semantics for `reconcile` exist in the structured contract.
+
+### Expected WAE behavior
+
+- The executor fails closed and reports unsupported/underspecified input.
+- WAE treats the unknown as unresolved semantic ownership if `reconcile` is actually
+  required by the product intent.
+- A semantic owner must define what `reconcile` means before the executor can become
+  mechanical again.
+
+### Must not happen
+
+- Do not guess that `reconcile` means `replace` or `merge`.
+- Do not derive semantics from the command name, nearby fields, historical frequency,
+  or provider conventions.
+- Do not claim Mechanical Boundary eligibility when unknown inputs are handled by
+  heuristic interpretation.
+
+### Pass condition
+
+Unknown semantic input cannot silently cross a boundary declared mechanical.
+
+---
+
+## Cross-case acceptance matrix
+
+| Case | Must refine | Must stop | Evidence may reopen | Must remain TPlan-free | Primary failure protected |
+|---|---:|---:|---:|---:|---|
+| OC-01 | no | yes | n/a | yes | false-positive escalation |
+| OC-02 | yes | after contract closure | yes | yes | Semantic Ownership Leakage |
+| OC-03 | no | yes | n/a | yes | over-Agenticization |
+| OC-04 | yes | after correction | yes | yes | green-test closure illusion |
+| OC-05 | no | yes | only with new semantics | yes | generic-loop confusion |
+| OC-06 | yes | after closure | yes | no: composed with TPlan | control-plane duplication |
+| OC-07 | conditional | yes at mechanical boundary | yes | yes | persistence overfitting |
+| OC-08 | yes if intent requires unknown kind | yes after definition | yes | yes | heuristic semantic invention |
+
+## Mechanical Boundary test
+
+Ownership refinement may stop only when the remaining work satisfies all of these:
+
+- input is complete and structured;
+- output/behavior is uniquely determined for admitted inputs;
+- no domain or business judgment remains;
+- validation/execution can be mechanical and domain-independent at that layer;
+- unknown or underspecified inputs fail closed rather than inventing semantics.
+
+This is a stopping test, not a requirement to introduce a new runtime validator or
+schema in this issue.
+
+## Expected public terminology
+
+The acceptance suite assumes these conceptual roles, while final wording may be refined
+without changing behavior:
+
+- `Ownership Closure` — the WAE target state / conditional mode;
+- `Ownership Boundary Refinement` — the mechanism for moving the boundary;
+- `Semantic Ownership Leakage` — semantic choice escapes through nominal delegation;
+- `Mechanical Boundary` — the point where deterministic consequence begins.
+
+`Recursive Ownership Refinement` may remain the design-observation name, but a passing
+implementation must not imply generic execution-loop semantics.
+
+## Freeze rule
+
+Substantive WAE implementation changes should be reviewed against these cases. If a
+case itself needs to change because the design proves incoherent, change the case
+explicitly and explain why; do not silently weaken an expectation to make an
+implementation pass.

--- a/tests/wae/ownership_closure_acceptance_review_2026-08-09.md
+++ b/tests/wae/ownership_closure_acceptance_review_2026-08-09.md
@@ -1,0 +1,108 @@
+# WAE Ownership Closure Acceptance Review
+
+Date: 2026-08-09
+Issue: #149
+Branch: `feat/wae-ownership-closure`
+Status: implementation review against frozen pre-implementation cases
+
+## Review basis
+
+This review uses the previously frozen
+`tests/wae/ownership_closure_acceptance_cases.md`. It does not add or weaken acceptance
+cases after implementation.
+
+The implementation under review is intentionally limited to:
+
+- `skills/wae/SKILL.md` conditional Ownership Closure mainline branch;
+- `skills/wae/resources/ownership-closure.md` deep semantics and boundaries;
+- `docs/methodologies/wae.md` public explanation;
+- `tests/test_wae_contract.py` regression contract.
+
+No WAE runtime state, task tree, schema, persistent ledger, or new governance gate was
+introduced.
+
+## Case review
+
+### OC-01 — First-order WAE is sufficient
+
+**Result: covered.**
+
+The skill states that Ownership Closure is a conditional extension rather than the
+default path. The Mechanical Boundary stops deeper inspection once structured input
+uniquely determines the admitted behavior.
+
+Residual risk: prose guidance cannot prove every model invocation will avoid
+false-positive escalation; this remains a behavior-evaluation candidate rather than a
+reason to add runtime ceremony now.
+
+### OC-02 — Hidden semantic choice behind a generic storage helper
+
+**Result: covered.**
+
+`Semantic Ownership Leakage` is defined as a nominal owner delegating work while a
+downstream component still makes a result-changing semantic choice. The mainline tells
+WAE to refine the owner or structured contract until the choice is explicit.
+
+### OC-03 — Mechanical Boundary stops refinement
+
+**Result: covered.**
+
+The stop test requires complete structured input, unique admitted behavior, no remaining
+domain judgment, mechanical validation sufficiency, and fail-closed unknown input. The
+resource explicitly states that ownership follows semantic choice rather than
+implementation depth.
+
+### OC-04 — Evidence reopens a nominally closed boundary
+
+**Result: covered.**
+
+Evidence may reopen closure only when it reveals a semantic remainder. Green unit,
+type, build, or mock evidence is not treated as proof that ownership is closed.
+
+### OC-05 — Execution retry is not Ownership Refinement
+
+**Result: covered.**
+
+The skill and resource distinguish a missing result-changing choice from a defective
+implementation of an already-complete choice. Ordinary `act -> test -> fix` work is
+explicitly outside Ownership Boundary Refinement.
+
+### OC-06 — TPlan hosts recurrence but does not own closure semantics
+
+**Result: covered.**
+
+The resource keeps Mission/task state, ordering, checkpoints, blockers, recovery,
+decision hooks, resumption, and lifecycle control in TPlan. WAE owns only semantic
+control-boundary and closure judgment. No duplicate runtime control plane was added.
+
+### OC-07 — Cross-domain semantic leakage
+
+**Result: covered.**
+
+The resource names persistence, API mapping, UI generation, and integration policy as
+examples while defining the rule by remaining semantic choice rather than technology
+layer.
+
+### OC-08 — Unknown mechanical input fails closed
+
+**Result: covered.**
+
+Unknown or underspecified input must be rejected or surfaced rather than interpreted
+heuristically. If product intent requires the unknown behavior, semantic ownership must
+be reopened before the layer can be called mechanical again.
+
+## Fidelity-schema decision
+
+The existing `wae-fidelity-v0.1` output contract remains unchanged in this issue.
+Ownership Closure is conditional. Making a new fidelity field unconditionally required
+would force every ordinary WAE invocation through Closure and violate OC-01.
+
+For this change, the frozen casebook plus `tests/test_wae_contract.py` protect the new
+method boundary. A future fidelity-schema revision should be considered only if live
+behavior evidence shows that the conditional judgment move cannot be preserved without
+an explicit versioned contract.
+
+## Review conclusion
+
+No acceptance case requires a new top-level methodology, WAE runtime, TPlan change,
+Schema, or Gate. The implementation is ready for repository CI and PR review.


### PR DESCRIPTION
## Summary

Upgrades WAE from first-order control assignment to a conditional **Ownership Closure** mode when delegation may hide unresolved result-changing semantic choices.

Key additions:

- freeze acceptance scenarios before implementation;
- define `Semantic Ownership Leakage`;
- define `Ownership Boundary Refinement` as semantic-boundary convergence, not a generic execution loop;
- stop at a conservative `Mechanical Boundary`;
- allow Evidence to reopen a closure judgment only when it reveals a semantic remainder;
- preserve TPlan as the long-running Mission/task runtime control plane;
- add WAE contract regression coverage without introducing a new executable test file or lifecycle-registry entry.

## Acceptance-first sequence

1. `tests/wae/ownership_closure_acceptance_cases.md` was committed first.
2. The frozen suite was reviewed for loop drift, over-Agenticization, persistence overfit, and TPlan duplication.
3. WAE skill/docs/resource changes were then implemented.
4. `tests/wae/ownership_closure_acceptance_review_2026-08-09.md` records the post-implementation review against the frozen cases.

## Deliberate non-goals

This PR does not add:

- a new top-level methodology or ROR skill;
- Mission/task/checkpoint/recovery state to WAE;
- a new schema, gate, validator, or persistent ledger;
- an unconditional new `wae-fidelity-v0.1` field.

The existing fidelity schema remains unchanged because Closure is conditional; making it universally required would violate the ordinary-WAE negative control.

Closes #149