### PR TITLE
fix: detect namespaced Mindthus skill loads

### DIFF
--- a/scripts/run-judgment-benchmark-cli.py
+++ b/scripts/run-judgment-benchmark-cli.py
@@ -54,7 +54,8 @@ REPAIR_ACTION_RE = re.compile(
 PATCH_SEGMENT_RE = re.compile(r"(?P<verb>补)(?P<unit>一段|段)(?P<object>[\u4e00-\u9fffA-Za-z]{0,4})")
 FORCED_MINDTHUS_RE = re.compile(r"\$mindthus:|mindthus:", re.IGNORECASE)
 MINDTHUS_SKILL_RE = re.compile(
-    r"(?:mindthus:|skills/)(using-mindthus|3l5s|sra|edsp|sela|mpg|wae|tvg|tplan)(?:/SKILL\.md)?",
+    r"(?:mindthus:|skills/(?:mindthus/)?)"
+    r"(using-mindthus|3l5s|sra|edsp|sela|mpg|wae|tvg|tplan)(?:/SKILL\.md)?",
     re.IGNORECASE,
 )
 

--- a/tests/test_judgment_benchmark_cli_runner.py
+++ b/tests/test_judgment_benchmark_cli_runner.py
@@ -665,6 +665,7 @@ class JudgmentBenchmarkCliRunnerTests(unittest.TestCase):
             [
                 "/bin/zsh -lc \"sed -n '1,220p' /tmp/plugins/cache/mindthus/mindthus/1.4.3/skills/using-mindthus/SKILL.md\"",
                 "/bin/zsh -lc \"sed -n '1,220p' /tmp/plugins/cache/mindthus/mindthus/1.4.3/skills/edsp/SKILL.md\"",
+                "/bin/zsh -lc \"sed -n '1,220p' /tmp/codex-home/skills/mindthus/sra/SKILL.md\"",
                 "Read mindthus:edsp",
                 "Read mindthus:sra",
                 "echo edsp and sra are mentioned but not loaded",


### PR DESCRIPTION
## Summary
- recognize Codex/OpenCode skills-pack paths such as `skills/mindthus/sra/SKILL.md` in benchmark runtime telemetry
- keep existing plugin and explicit `mindthus:*` detection
- add regression coverage for the namespaced Codex layout

## Evidence
- `python3 -m unittest tests.test_judgment_benchmark_cli_runner tests.test_sra_wakeup_and_boundaries`
- 50 tests passed
- SRA natural-wakeup smoke record now reports `loaded_owner: [using-mindthus, sra]` instead of a false no-load

Relates to #156.