### PR TITLE
fix: keep SRA passive routing within its boundary

### DIFF
--- a/skills/sra/SKILL.md
+++ b/skills/sra/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sra
-description: "Use directly when multiple already-judgeable actions or bundles compete for the same scarce resource. Default to Lite for one bounded tranche; use Full for bundles, multiple constrained resources, fixed thresholds, or major or irreversible commitments."
+description: "Use directly when multiple already-judgeable actions or bundles compete for one named scarce resource; choose the next tranche. Default Lite; Full for bundles or multiple resource constraints. Do not use with missing comparison facts/resource, or for one selected mainline's carrier, exposure, timing, or exit."
 ---
 
 # SRA / Scarce Resource Allocation / 稀缺资源优先分配

--- a/skills/using-mindthus/SKILL.md
+++ b/skills/using-mindthus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-mindthus
-description: Use when any Mindthus judgment lens may apply; allocation ambiguity before choosing SRA; strategic/path/control/framing ambiguity before choosing SELA, MPG, EDSP, WAE, TVG, 3L5S, or tplan. Entry Triage hard-judgment cues;whole-object reduction, forced structural binary, repeated local repair, no-data numeric comparison
+description: Use when any Mindthus judgment lens may apply; strategic/path/control/framing ambiguity before choosing SELA, MPG, EDSP, WAE, TVG, 3L5S, or tplan. Entry Triage hard-judgment cues include whole-object reduction, forced structural binary, repeated local repair, and no-data numeric comparison; not ordinary missing facts; SRA only after multiple candidates share a scarce resource.
 ---
 
 ## Core Claim
@@ -11,7 +11,7 @@ signal, constraint, or hypothesis; not evidence by itself.
 ## Mainline
 
 Premise Calibration / 前置校准 is not a method. Before lens choice, check
-真实对象, 底层约束, and 目标函数.
+真实对象, 底层约束, 目标函数.
 
 Before routing, classify:
 
@@ -114,11 +114,11 @@ information, clarify, or reroute.
 
 ## Guardrails
 
-Guardrails support mainline, not judgment center.
+Supports mainline.
 
 ### Conditional Resources / Runtime Support
 
-Do not preload every resource. Read only for uncertainty:
+Do not preload every resource:
 
 Portable alias: `resources/primitives/`.
 
@@ -139,5 +139,5 @@ Portable alias: `resources/primitives/`.
 
 ## Boundaries
 
-No hard judgment point, no Mindthus. Missing facts first. Stop when another method owns
-the decision or analysis lacks a value-gain hypothesis.
+No hard judgment, no Mindthus. Missing facts first. Stop when another method owns the
+decision or no value-gain hypothesis exists.

--- a/tests/test_sra_wakeup_and_boundaries.py
+++ b/tests/test_sra_wakeup_and_boundaries.py
@@ -99,7 +99,9 @@ class SraWakeupAndBoundaryAuditTests(unittest.TestCase):
         frontmatter = text.split("---", 2)[1]
         self.assertIn("Use directly when", frontmatter)
         self.assertIn("already-judgeable actions or bundles", frontmatter)
-        self.assertIn("same scarce resource", frontmatter)
+        self.assertIn("one named scarce resource", frontmatter)
+        self.assertIn("missing comparison facts/resource", frontmatter)
+        self.assertIn("one selected mainline's carrier, exposure, timing, or exit", frontmatter)
         for forbidden in (
             "must use 3l5s",
             "requires 3l5s",
@@ -139,6 +141,16 @@ class SraWakeupAndBoundaryAuditTests(unittest.TestCase):
                 text = path.read_text(encoding="utf-8")
                 self.assertIn("Use directly when", text)
                 self.assertIn("already-judgeable actions or bundles", text)
+
+    def test_passive_descriptions_reject_missing_inputs_and_single_mainline_carriers(self):
+        using_frontmatter = USING.read_text(encoding="utf-8").split("---", 2)[1]
+        sra = SRA_SKILL.read_text(encoding="utf-8")
+
+        self.assertIn("not ordinary missing facts", using_frontmatter)
+        self.assertIn(
+            "SRA only after multiple candidates share a scarce resource",
+            using_frontmatter,
+        )
 
     def test_router_and_entry_triage_expose_the_same_sra_signature(self):
         using = USING.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- tighten the SRA discovery description to require judgeable candidates and one named contested resource
- keep ordinary missing-input requests direct
- keep one selected mainline carrier/exposure/timing decisions with MPG
- add executable boundary assertions while preserving skill entrypoint size budgets

## Root cause
Codex chooses candidate skills from frontmatter before reading full method boundaries. The prior SRA description included Full-mode commitment cues but omitted the two strongest negative boundaries, so an MPG carrier case and an information-acquisition control could preload SRA.

## Evidence
- 12 focused tests pass, including packaging size/word budgets
- fresh holdout #16: loaded owners changed from `[using-mindthus, mpg, sra, sela]` to `[mpg, sela]`
- fresh holdout #23: loaded owners changed from `[using-mindthus, sra]` to `[]`
- no TPlan hook/schema/runtime files changed

Relates to #156.