### PR TITLE
fix(sra): close final v0.3 release blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Host 根据自然语言自行发现并唤起 Mindthus 属于 **best-effort** 能
 
 本仓库不是 Python library；安装的含义是把 `skills/` 暴露给目标 agent client。
 
+开发、测试和发版验证要求 **CPython 3.10+**。GitHub Actions 固定使用 Python 3.11；
+本地验证不要默认系统中的 `python3` 一定满足要求，应先运行 `python3 --version`，
+版本较低时使用明确的受支持解释器，例如 `python3.10`、`python3.11` 或 `python3.12`。
+完整测试命令中的解释器名称也应使用同一个受支持版本。
+
 ## 安装
 
 ### 选择下载包
@@ -268,22 +273,29 @@ cp -R /tmp/mindthus-skills/opencode/.opencode /path/to/your/opencode-project/
 - [Mindthus Judgment Benchmark Latest](docs/benchmarks/latest.md)
 - [Before/after explanatory examples](docs/cases/before-after/) show what the benchmark is trying to measure; they are not quantitative proof.
 
+先固定本轮验证使用的受支持解释器：
+
+```bash
+export MINDTHUS_PYTHON=python3.11
+"$MINDTHUS_PYTHON" --version
+```
+
 运行文档与打包检查：
 
 ```bash
-python3 -m unittest tests.test_packaging_docs -v
+"$MINDTHUS_PYTHON" -m unittest tests.test_packaging_docs -v
 ```
 
 运行 `tplan` runtime 检查：
 
 ```bash
-python3 -m unittest discover -s tests/tplan -v
+"$MINDTHUS_PYTHON" -m unittest discover -s tests/tplan -v
 ```
 
 运行完整测试：
 
 ```bash
-python3 -m unittest discover -s tests -v
+"$MINDTHUS_PYTHON" -m unittest discover -s tests -v
 ```
 
 ## 可选：记录使用效果

--- a/docs/internal/audits/2026-09-04-sra-v0.3-final-validation-remediation.md
+++ b/docs/internal/audits/2026-09-04-sra-v0.3-final-validation-remediation.md
@@ -1,0 +1,135 @@
+# SRA v0.3 Final Validation Remediation
+
+Date: 2026-09-04
+Base: `origin/main` at `9070d42b3081c839163ceae967820c6a4a5713ee`
+Branch: `fix/sra-v03-release-blockers`
+Status: implementation and local verification complete; independent post-fix revalidation still required before release
+
+## Trigger
+
+A fresh Codex validation of the merged SRA v0.3 implementation reported two release-blocking contract gaps:
+
+1. Lite could authorize a candidate's current allocation and next tranche separately even when their cumulative measured commitment exceeded that candidate's declared resource demand.
+2. Repair could rebuild a modified `raw-input.json` when the trace was absent and `run.json` was non-empty but no longer contained a complete prepared-input hash anchor.
+
+The same validation also observed that an unqualified local `python3` could resolve to Python 3.9 and fail during test discovery, while the suite passed under Python 3.12.
+
+## Independent Reproduction
+
+Both blockers were reproduced on the merged `main` commit before implementation changes.
+
+### Cumulative candidate demand
+
+A Lite judgment was constructed with:
+
+```text
+candidate demand:          1.0 engineer-day
+current allocation:        0.6 engineer-day
+next tranche:              0.9 engineer-day
+resource-pool capacity:    2.0 engineer-days
+investment ceiling:        1.5 engineer-days
+```
+
+Each allocation independently fit the candidate demand, pool capacity, and investment ceiling. Their cumulative candidate commitment was 1.5 engineer-days and the validator returned no findings.
+
+### Missing prepared-input anchor
+
+A prepared run was changed as follows:
+
+- `trace.jsonl` was removed;
+- the raw input was changed to another shape-valid objective;
+- the six raw/context/packet input-anchor fields were removed from `run.json` while the remaining cache object was retained.
+
+Repair accepted the non-empty cache, rebuilt all derived hashes around the changed input, and returned a clean result.
+
+## Root Causes
+
+### Demand validation was local rather than cumulative
+
+The validator checked `current_allocations` and `next_tranche.resource_allocations` independently against candidate demand. The global resource envelope checked pool capacity and investment ceiling, but no invariant aggregated one candidate's current-plus-next commitment against that candidate's own demand.
+
+### Repair tested anchor presence weakly
+
+Repair treated any non-empty run-state object as a fallback prepared-input anchor. Hash and packet fields were compared only when present, so an incomplete cache could silently cease to be an anchor while still enabling reconstruction.
+
+## Corrections
+
+### Cumulative demand invariant
+
+The canonical resource domain now validates one candidate's cumulative current-window commitment:
+
+```text
+candidate current allocation
++ candidate next tranche
+<= candidate declared resource demand
+```
+
+The check follows the resource contract:
+
+- measured resources sum exact or bounded upper commitments;
+- ordinal resources retain exclusive allocation semantics;
+- indivisible resources use non-duplicated block-set containment.
+
+It applies to Lite, Full, challenge, situated, and reconciliation judgments through the shared decision validator.
+
+### Complete prepared-input anchor
+
+A prepared-input anchor now contains all of:
+
+```text
+raw_input_hash
+context_admission_hash
+base_packet_hash
+coverage_packet_hash
+challenge_packet_hash
+situated_packet_hash
+```
+
+The `run_prepared` trace event now records the two previously absent input hashes. Repair requires a complete and matching anchor from either:
+
+- the valid `run_prepared` trace event; or
+- the version-valid run-state cache.
+
+An arbitrary non-empty or partially stripped `run.json` is no longer accepted as an input authority. A complete state-only anchor and a complete trace-only anchor both remain valid repair paths.
+
+### Python validation boundary
+
+The README now declares CPython 3.10+ as the development, test, and release-validation floor. GitHub Actions remains pinned to Python 3.11. Local validation instructions require selecting one supported interpreter explicitly through `MINDTHUS_PYTHON` rather than assuming the system `python3` is suitable.
+
+## Regression Evidence
+
+New permanent tests cover:
+
+- Lite cumulative exact demand overflow;
+- cumulative commitment exactly equal to demand;
+- bounded-demand cumulative overflow;
+- complete input anchors in `run_prepared`;
+- rejection of incomplete state anchor when trace is absent;
+- successful repair from complete state-only anchor;
+- successful repair from complete trace-only anchor;
+- rejection of changed raw input under a state-only anchor;
+- documented CPython 3.10+ floor and pinned Python 3.11 CI.
+
+## Verification
+
+Local supported-interpreter verification used CPython 3.10.12:
+
+```text
+SRA-focused and CI contract tests: 216 passed
+complete unittest suite:            1022 passed, 5 skipped
+Test Lifecycle registry:            valid, 76/76 executable test files registered
+release-pack build:                 PASS for package=all
+packaged sra_domain.py copies:      5
+packaged repair_sra_run.py copies:  5
+git diff --check:                   PASS
+```
+
+The skipped tests depend on optional local packages and are not failures.
+
+## Claim Boundary
+
+These corrections establish the missing deterministic resource-demand and prepared-input-anchor invariants. They do not make local files tamper-proof against an actor who can coherently replace every anchor, nor do they prove semantic priority, bundle sufficiency, or real-world allocation optimality.
+
+## Release Decision
+
+Release remains paused until the post-fix branch passes remote CI and receives a fresh independent revalidation of the two original counterexamples.

--- a/skills/sra/SKILL.md
+++ b/skills/sra/SKILL.md
@@ -168,8 +168,9 @@ continuation is best.
 
 ### Keep Workflow Deterministic
 
-Workflow validates references, resource contracts, candidate demand, bundle membership,
-posture consistency, capacity, ceilings, state transitions, and typed disagreement. It
+Workflow validates references, resource contracts, each candidate's cumulative current
+plus next-tranche demand, bundle membership, posture consistency, capacity, ceilings,
+state transitions, and typed disagreement. It
 does not decide semantic necessity, risk acceptance, bundle sufficiency, strongest
 alternative, or priority.
 

--- a/skills/sra/resources/context-isolation.md
+++ b/skills/sra/resources/context-isolation.md
@@ -188,8 +188,9 @@ depend on, unlock, or substitute for itself. At least one pool must be demanded 
 more candidates; otherwise SRA has no demonstrated shared resource contention.
 
 Actual current allocation, next tranche, and bundle requirements must reference resources
-contained in the relevant candidate demand. Measured and bounded quantities cannot exceed
-that demand; ordinal levels and indivisible blocks must remain within the declared
+contained in the relevant candidate demand. A candidate's current allocation plus its
+next tranche is one cumulative commitment for the decision window and must remain within
+that demand. Ordinal levels and indivisible blocks remain within the same declared
 candidate boundary.
 
 ### Evidence
@@ -490,12 +491,15 @@ Agentic judgments:
 - run cache;
 - trace.
 
-It never edits Agentic judgment files. Prepared packet hashes anchor the raw input; recorded judgment-event hashes anchor
-Agentic judgments; trace carrier facts take precedence over the mutable run cache. Repair
-requires at least one prepared-input anchor and accepts only regular in-run authoritative
-files and judgment directories. It refuses changed raw input, changed Agentic judgments,
-invalid or illegally ordered judgments, another runtime version, symbolic-link escapes,
-invalid stage receipt paths, or missing unrecoverable carrier facts.
+It never edits Agentic judgment files. A complete prepared-input anchor contains the raw
+input hash, context-admission hash, and every initial packet hash. Repair requires that
+complete anchor from either the `run_prepared` trace event or the run-state cache and
+requires it to match the current raw input. Recorded judgment-event hashes anchor Agentic
+judgments; valid trace carrier facts take precedence over the mutable run cache. Repair
+accepts only regular in-run authoritative files and judgment directories. It refuses
+changed raw input, incomplete prepared-input anchors, changed Agentic judgments, invalid
+or illegally ordered judgments, another runtime version, symbolic-link escapes, invalid
+stage receipt paths, or missing unrecoverable carrier facts.
 
 ## Carrier Boundary
 

--- a/skills/sra/resources/methodology.md
+++ b/skills/sra/resources/methodology.md
@@ -437,7 +437,8 @@ Runtime quantities preserve their native meaning:
 
 Candidate demand, current allocation, bundle requirements, next tranche, reserve, and
 investment ceiling all reference the same resource-pool contract. Workflow checks
-mechanical compatibility and capacity; Agentic SRA still decides semantic value.
+mechanical compatibility, capacity, and each candidate's cumulative current-plus-next
+commitment against its declared demand; Agentic SRA still decides semantic value.
 
 The runtime records one allocation-ledger row per candidate:
 
@@ -809,7 +810,8 @@ Scripts may:
 - build a declared-fragment context-admission ledger and shared decision base;
 - align candidate cards and create input-order-independent challenge aliases;
 - validate measured, ordinal, and indivisible resource contracts;
-- bind actual allocation and bundle requirements to candidate demand;
+- bind actual allocation and bundle requirements to candidate demand, including each
+  candidate's cumulative current-plus-next commitment;
 - reject pre-decided semantic role or score fields;
 - generate independent challenge and situated packets plus deterministic Prompt, schema,
   Dispatch, and command surfaces;

--- a/skills/sra/scripts/prepare_sra_run.py
+++ b/skills/sra/scripts/prepare_sra_run.py
@@ -137,6 +137,8 @@ def prepare(input_path: Path, run_dir: Path) -> dict[str, object]:
                 "mode": built["mode"],
                 "view_plan": built["view_plan"],
                 "coverage_plan": built["coverage_plan"],
+                "raw_input_hash": built["raw_input_hash"],
+                "context_admission_hash": built["context_admission_hash"],
                 "base_packet_hash": built["base_packet"]["packet_hash"],
                 "coverage_packet_hash": built["coverage_packet"]["packet_hash"],
                 "challenge_packet_hash": built["challenge_packet"]["packet_hash"],

--- a/skills/sra/scripts/sra_domain.py
+++ b/skills/sra/scripts/sra_domain.py
@@ -606,6 +606,57 @@ def validate_allocations_against_demand(
             )
 
 
+def validate_cumulative_allocations_against_demand(
+    *allocation_groups: Any,
+    demands: Any,
+    path: str,
+    resource_pools: Iterable[dict[str, Any]],
+    findings: list[str],
+) -> None:
+    """Validate one candidate's total current-window commitment against its demand."""
+    contracts = resource_contracts(resource_pools)
+    demand_by_resource = _allocation_map(demands)
+    cumulative = _quantities_by_resource(*allocation_groups)
+    for resource_id, quantities in cumulative.items():
+        demand = demand_by_resource.get(resource_id)
+        contract = contracts.get(resource_id)
+        if demand is None:
+            findings.append(
+                f"{path}.{resource_id} is not declared in the candidate resource demand"
+            )
+            continue
+        if contract is None:
+            continue
+        family = contract.get("family")
+        if family == "measured":
+            total = _combined_measured_upper(quantities)
+            limit = _quantity_upper(demand)
+            if total is None or limit is None or total > limit + 1e-12:
+                findings.append(
+                    f"{path}.{resource_id} cumulative allocation exceeds or conflicts "
+                    "with the candidate resource demand"
+                )
+        elif family == "ordinal":
+            if len(quantities) != 1 or not quantity_within(
+                quantities[0], demand, contract
+            ):
+                findings.append(
+                    f"{path}.{resource_id} cumulative allocation exceeds or conflicts "
+                    "with the candidate resource demand"
+                )
+        elif family == "indivisible":
+            blocks = [
+                block for quantity in quantities for block in (_block_set(quantity) or set())
+            ]
+            demand_blocks = _block_set(demand) or set()
+            duplicates = any(count > 1 for count in Counter(blocks).values())
+            if duplicates or not set(blocks) <= demand_blocks:
+                findings.append(
+                    f"{path}.{resource_id} cumulative allocation exceeds or conflicts "
+                    "with the candidate resource demand"
+                )
+
+
 def _quantities_by_resource(*allocation_groups: Any) -> dict[str, list[dict[str, Any]]]:
     result: dict[str, list[dict[str, Any]]] = {}
     for group in allocation_groups:

--- a/skills/sra/scripts/sra_runtime_core.py
+++ b/skills/sra/scripts/sra_runtime_core.py
@@ -2205,6 +2205,22 @@ def _validate_decision_judgment(
         if not isinstance(start_condition, str):
             findings.append("next_tranche.start_condition must be a string")
 
+    for candidate_id in sorted(str(item) for item in allowed_candidates):
+        current_allocations = ledger_by_id.get(candidate_id, {}).get(
+            "current_allocations", []
+        )
+        candidate_next_allocations = (
+            next_allocations if target_id == candidate_id else []
+        )
+        validate_cumulative_allocations_against_demand(
+            current_allocations,
+            candidate_next_allocations,
+            demands=demands.get(candidate_id, []),
+            path=f"candidate {candidate_id} cumulative commitment",
+            resource_pools=resource_pools,
+            findings=findings,
+        )  # noqa: F405
+
     investment_ceiling = judgment.get("investment_ceiling")
     validate_resource_allocations(
         investment_ceiling,

--- a/skills/sra/scripts/sra_runtime_integrity.py
+++ b/skills/sra/scripts/sra_runtime_integrity.py
@@ -25,6 +25,14 @@ RUN_STATE_KEYS = frozenset({
 RECEIPT_KEYS = frozenset({
     "source_path", "stored_path", "sha256", "bytes", "boundary",
 })
+PREPARED_INPUT_ANCHOR_FIELDS = (
+    "raw_input_hash",
+    "context_admission_hash",
+    "base_packet_hash",
+    "coverage_packet_hash",
+    "challenge_packet_hash",
+    "situated_packet_hash",
+)
 
 
 def _parse_utc_timestamp(value: Any) -> datetime | None:
@@ -295,6 +303,8 @@ def expected_trace_events(
             "mode": rebuilt["mode"],
             "view_plan": rebuilt["view_plan"],
             "coverage_plan": rebuilt["coverage_plan"],
+            "raw_input_hash": rebuilt["raw_input_hash"],
+            "context_admission_hash": rebuilt["context_admission_hash"],
             "base_packet_hash": rebuilt["base_packet"]["packet_hash"],
             "coverage_packet_hash": rebuilt["coverage_packet"]["packet_hash"],
             "challenge_packet_hash": rebuilt["challenge_packet"]["packet_hash"],
@@ -1066,39 +1076,43 @@ def _repair_trace_anchors(run_dir: Path, run_id: str) -> dict[str, Any]:
 
 def _validate_repair_anchors(
     *,
-    raw: dict[str, Any],
     rebuilt: dict[str, Any],
     expectation: dict[str, Any],
     state: dict[str, Any],
     trace_anchors: dict[str, Any],
 ) -> None:
     prepared = trace_anchors.get("prepared")
-    packet_fields = {
+    expected_input_anchor = {
+        "raw_input_hash": rebuilt["raw_input_hash"],
+        "context_admission_hash": rebuilt["context_admission_hash"],
         "base_packet_hash": rebuilt["base_packet"]["packet_hash"],
         "coverage_packet_hash": rebuilt["coverage_packet"]["packet_hash"],
         "challenge_packet_hash": rebuilt["challenge_packet"]["packet_hash"],
         "situated_packet_hash": rebuilt["situated_packet"]["packet_hash"],
     }
-    if not isinstance(prepared, dict) and not state:
-        raise SraRuntimeError(  # noqa: F405
-            "cannot repair without a prepared-input anchor in trace or run state"
+
+    def complete_input_anchor(value: Any) -> bool:
+        return isinstance(value, dict) and all(
+            isinstance(value.get(field), str) and bool(value.get(field))
+            for field in PREPARED_INPUT_ANCHOR_FIELDS
         )
-    if isinstance(prepared, dict):
-        for field, current in packet_fields.items():
-            if prepared.get(field) != current:
-                raise SraRuntimeError(  # noqa: F405
-                    f"cannot repair changed raw input: prepared {field} does not match"
-                )
-    elif state:
-        raw_hash = state.get("raw_input_hash")
-        if isinstance(raw_hash, str) and raw_hash != digest_data(raw):  # noqa: F405
-            raise SraRuntimeError("cannot repair changed raw-input.json")  # noqa: F405
-        for field, current in packet_fields.items():
-            anchored = state.get(field)
-            if isinstance(anchored, str) and anchored != current:
-                raise SraRuntimeError(  # noqa: F405
-                    f"cannot repair changed raw input: run state {field} does not match"
-                )
+
+    if complete_input_anchor(prepared):
+        anchor_name = "prepared trace"
+        input_anchor = prepared
+    elif complete_input_anchor(state):
+        anchor_name = "run state"
+        input_anchor = state
+    else:
+        raise SraRuntimeError(  # noqa: F405
+            "cannot repair without a complete prepared-input anchor in trace or run state"
+        )
+
+    for field in PREPARED_INPUT_ANCHOR_FIELDS:
+        if input_anchor.get(field) != expected_input_anchor[field]:
+            raise SraRuntimeError(  # noqa: F405
+                f"cannot repair changed raw input: {anchor_name} {field} does not match"
+            )
 
     trace_hashes = trace_anchors.get("judgment_hashes", {})
     if not isinstance(trace_hashes, dict):
@@ -1238,7 +1252,6 @@ def repair_run(run_dir: Path) -> dict[str, Any]:
             + "; ".join(expectation["issues"])
         )
     _validate_repair_anchors(
-        raw=raw,
         rebuilt=rebuilt,
         expectation=expectation,
         state=existing_state,

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO / ".github" / "workflows" / "python-validation.yml"
+README = REPO / "README.md"
 
 
 class CiWorkflowTests(unittest.TestCase):
@@ -14,6 +15,7 @@ class CiWorkflowTests(unittest.TestCase):
         for phrase in (
             "actions/checkout",
             "actions/setup-python",
+            'python-version: "3.11"',
             "python3 -m unittest tests.test_packaging_docs -v",
             "python3 -m unittest discover -s tests/tplan -v",
             "python3 -m unittest discover -s tests -q",
@@ -23,6 +25,15 @@ class CiWorkflowTests(unittest.TestCase):
             "unittest is canonical",
         ):
             self.assertIn(phrase, text)
+
+    def test_release_validation_documents_supported_python_floor(self):
+        text = README.read_text(encoding="utf-8")
+        self.assertIn("CPython 3.10+", text)
+        self.assertIn("python3 --version", text)
+        self.assertIn("export MINDTHUS_PYTHON=python3.11", text)
+        self.assertIn('"$MINDTHUS_PYTHON" -m unittest discover -s tests -v', text)
+        for interpreter in ("python3.10", "python3.11", "python3.12"):
+            self.assertIn(interpreter, text)
 
 
 if __name__ == "__main__":

--- a/tests/test_sra_v03_runtime_contract.py
+++ b/tests/test_sra_v03_runtime_contract.py
@@ -434,6 +434,90 @@ class SraV03RuntimeContractTests(unittest.TestCase):
         findings = validate_situated_judgment(judgment, packet)
         self.assertTrue(any("resource demand" in item for item in findings))
 
+    def test_lite_cumulative_candidate_commitment_cannot_exceed_demand(self):
+        data = input_data()
+        engineer_pool = next(
+            item
+            for item in data["allocation_frame"]["resource_pools"]
+            if item["resource_id"] == "engineer-time"
+        )
+        engineer_pool["capacity"] = exact(2)
+        packet = build_packets(data)["situated_packet"]
+        judgment = situated_judgment(packet)
+        payment_row = next(
+            item
+            for item in judgment["allocation_ledger"]
+            if item["candidate_id"] == "payment-validation"
+        )
+        payment_row["posture"] = "floor"
+        payment_row["current_allocations"] = [allocation("engineer-time", 0.6)]
+        judgment["investment_ceiling"] = [allocation("engineer-time", 1.5)]
+        findings = validate_situated_judgment(judgment, packet)
+        self.assertTrue(
+            any("cumulative" in item and "candidate resource demand" in item for item in findings),
+            findings,
+        )
+
+    def test_lite_cumulative_candidate_commitment_equal_to_demand_passes(self):
+        data = input_data()
+        engineer_pool = next(
+            item
+            for item in data["allocation_frame"]["resource_pools"]
+            if item["resource_id"] == "engineer-time"
+        )
+        engineer_pool["capacity"] = exact(2)
+        packet = build_packets(data)["situated_packet"]
+        judgment = situated_judgment(packet)
+        payment_row = next(
+            item
+            for item in judgment["allocation_ledger"]
+            if item["candidate_id"] == "payment-validation"
+        )
+        payment_row["posture"] = "floor"
+        payment_row["current_allocations"] = [allocation("engineer-time", 0.1)]
+        judgment["investment_ceiling"] = [allocation("engineer-time", 1)]
+        self.assertEqual(validate_situated_judgment(judgment, packet), [])
+
+    def test_lite_bounded_demand_applies_to_cumulative_commitment(self):
+        data = input_data()
+        engineer_pool = next(
+            item
+            for item in data["allocation_frame"]["resource_pools"]
+            if item["resource_id"] == "engineer-time"
+        )
+        engineer_pool["capacity"] = exact(2)
+        payment = next(
+            item
+            for item in data["candidates"]
+            if item["candidate_id"] == "payment-validation"
+        )
+        payment["resource_demand"] = [
+            {
+                "resource_id": "engineer-time",
+                "quantity": {
+                    "quantity_kind": "bounded",
+                    "lower_bound": 0,
+                    "upper_bound": 1,
+                    "unit": "engineer-day",
+                },
+            }
+        ]
+        packet = build_packets(data)["situated_packet"]
+        judgment = situated_judgment(packet)
+        payment_row = next(
+            item
+            for item in judgment["allocation_ledger"]
+            if item["candidate_id"] == "payment-validation"
+        )
+        payment_row["posture"] = "floor"
+        payment_row["current_allocations"] = [allocation("engineer-time", 0.2)]
+        judgment["investment_ceiling"] = [allocation("engineer-time", 1.1)]
+        findings = validate_situated_judgment(judgment, packet)
+        self.assertTrue(
+            any("cumulative" in item and "candidate resource demand" in item for item in findings),
+            findings,
+        )
+
     def test_selected_full_bundle_must_contain_next_candidate(self):
         packet = build_packets(input_data(mode="full"))["situated_packet"]
         judgment = situated_judgment(packet)

--- a/tests/test_sra_v03_runtime_lifecycle.py
+++ b/tests/test_sra_v03_runtime_lifecycle.py
@@ -49,6 +49,22 @@ class SraV03RuntimeLifecycleTests(unittest.TestCase):
         report = run_check(run_dir)
         self.assertEqual(report["status"], "ok", report)
 
+    def test_run_prepared_trace_carries_complete_input_anchor(self):
+        run_dir = self.prepare_run()
+        event = json.loads(
+            (run_dir / "trace.jsonl").read_text(encoding="utf-8").splitlines()[0]
+        )
+        for field in (
+            "raw_input_hash",
+            "context_admission_hash",
+            "base_packet_hash",
+            "coverage_packet_hash",
+            "challenge_packet_hash",
+            "situated_packet_hash",
+        ):
+            self.assertIn(field, event["payload"])
+            self.assertTrue(event["payload"][field])
+
     def test_prompt_tamper_is_detected(self):
         run_dir = self.prepare_run()
         path = run_dir / "challenge-agent-prompt.md"
@@ -518,6 +534,58 @@ class SraV03RuntimeLifecycleTests(unittest.TestCase):
         raw["allocation_frame"]["parent_objective"] = "A replacement objective."
         raw_path.write_text(json.dumps(raw), encoding="utf-8")
         with self.assertRaises(SraRuntimeError):
+            repair_run(run_dir)
+
+    def test_repair_rejects_incomplete_state_anchor_when_trace_is_missing(self):
+        run_dir = self.prepare_run()
+        (run_dir / "trace.jsonl").unlink()
+        state_path = run_dir / "run.json"
+        state = load_json(state_path)
+        for field in (
+            "raw_input_hash",
+            "context_admission_hash",
+            "base_packet_hash",
+            "coverage_packet_hash",
+            "challenge_packet_hash",
+            "situated_packet_hash",
+        ):
+            state.pop(field, None)
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+        raw_path = run_dir / "raw-input.json"
+        raw = load_json(raw_path)
+        raw["allocation_frame"]["parent_objective"] = "A replacement objective."
+        raw_path.write_text(json.dumps(raw), encoding="utf-8")
+        with self.assertRaisesRegex(SraRuntimeError, "prepared-input anchor"):
+            repair_run(run_dir)
+
+    def test_repair_accepts_complete_state_anchor_when_trace_is_missing(self):
+        run_dir = self.prepare_run()
+        (run_dir / "trace.jsonl").unlink()
+        prompt_path = run_dir / "situated-agent-prompt.md"
+        prompt_path.write_text("tampered", encoding="utf-8")
+        result = repair_run(run_dir)
+        self.assertTrue(result["repaired"], result)
+        self.assertEqual(run_check(run_dir)["status"], "ok")
+        self.assertNotEqual(prompt_path.read_text(encoding="utf-8"), "tampered")
+
+    def test_repair_accepts_complete_trace_anchor_when_state_is_missing(self):
+        run_dir = self.prepare_run()
+        (run_dir / "run.json").unlink()
+        prompt_path = run_dir / "situated-agent-prompt.md"
+        prompt_path.write_text("tampered", encoding="utf-8")
+        result = repair_run(run_dir)
+        self.assertTrue(result["repaired"], result)
+        self.assertEqual(run_check(run_dir)["status"], "ok")
+        self.assertNotEqual(prompt_path.read_text(encoding="utf-8"), "tampered")
+
+    def test_repair_rejects_changed_raw_input_with_state_only_anchor(self):
+        run_dir = self.prepare_run()
+        (run_dir / "trace.jsonl").unlink()
+        raw_path = run_dir / "raw-input.json"
+        raw = load_json(raw_path)
+        raw["allocation_frame"]["parent_objective"] = "A replacement objective."
+        raw_path.write_text(json.dumps(raw), encoding="utf-8")
+        with self.assertRaisesRegex(SraRuntimeError, "run state raw_input_hash"):
             repair_run(run_dir)
 
     def test_raw_input_must_be_regular_in_run_file(self):


### PR DESCRIPTION
## Summary

- enforce cumulative candidate demand across current allocation plus next tranche
- require a complete prepared-input anchor from trace or run state before Repair
- add raw-input and context-admission hashes to the `run_prepared` trace event
- document and test the CPython 3.10+ release-validation floor with CI pinned to 3.11
- add regression coverage and a remediation audit for the independent Codex findings

## Reproduced blockers

Both findings failed before the fix:

1. Lite accepted 0.6 current + 0.9 next against candidate demand 1.0 when pool capacity and ceiling were larger.
2. Repair accepted changed raw input after trace removal when hash fields were stripped from an otherwise non-empty run cache.

## Verification

- targeted blocker regressions: PASS
- SRA/CI focused suite: 216 tests PASS
- full suite under CPython 3.10.12: 1022 PASS, 5 optional-dependency skips
- test-lifecycle registry: valid, 76/76 executable test files registered
- `git diff --check`: PASS
- all-layout release pack: PASS; SRA domain and Repair CLI present in all 5 layouts

## Release boundary

Release remains paused until this PR passes remote CI and the original independent reviewer reruns the two counterexamples. This fix does not claim tamper-proof local storage or semantic allocation optimality.