### PR TITLE
fix(sra): canonical reception contract and maintenance plan

### DIFF
--- a/docs/internal/audits/2026-09-05-maintenance-plan-review-a.md
+++ b/docs/internal/audits/2026-09-05-maintenance-plan-review-a.md
@@ -1,0 +1,25 @@
+# 方案审计 A：合同与测试保护
+
+日期：2026-09-05
+对象：docs/internal/maintenance-20260905-plan.md v1.1
+源码基线：1de31845cce25126651231d51047564eb055e1da
+载体：本会话 ChatGPT 自身；按用户最新指令执行。非外部 reviewer、非新上下文。
+
+## 审计问题
+
+依赖授权修复是否引入错误的完成判断？结构统一能否覆盖真实接收入口？测试清理是否以数量取代保护价值？
+
+## 检查与发现
+
+1. 查看 sra_runtime_core 的候选校验、Schema 生成和 judgment 接收逻辑：现有 depends_on 只检查 ID 引用，不能证明前置满足。v1.0 草案的五状态 waiver/substitute 容易在没有权限载体的情况下增加伪授权通道。v1.1 收敛到 satisfied/unmet/unknown；替代/豁免暂不建立新的 runtime 例外。已完成前置仍可零投入。
+2. satisfied 的 evidence_refs 合法不证明事实真实。方案保留 Agentic 语义判断，Workflow 只检查边覆盖、引用及授权后果。当前资源与下一 tranche 都受前置约束，不能只检查后者。
+3. 必须区分“前置列在组合里”和“前置已完成”。选择 B 且 A 未满足时不能立即投 B；选择 A 先做可以合法；conditional 仅保留计划，不授予当前投入。
+4. Schema 已使用 oneOf/anyOf/not/pattern 等约束。只检查根字段不足，结构解释器必须拒绝不支持的 Schema 关键字，错误结构先返回而不送入假定类型正确的领域逻辑。
+5. 没有依据把所有旧测试归为无效。沿用 lifecycle 逐项替代台账；安全/权限/恢复回归保持；故障变体用于证明替代 owner 真能捕获原风险。
+6. 新字段对旧 run 的行为变化必须可见。无依赖 v0.3 结构保持；有依赖而缺解析记录明确不足，准备新 run，禁止 Repair 改造原始权威。
+
+## 结论
+
+v1.1 已纳入上述收敛，方案允许进入分项实施。实施代码仍需反例和正例验证，方案通过不等于产品修复通过。遗留子项不能因为父计划被接受而自动关闭。
+
+Verdict: PASS for implementation planning, with explicit implementation gates.

--- a/docs/internal/audits/2026-09-05-maintenance-plan-review-b.md
+++ b/docs/internal/audits/2026-09-05-maintenance-plan-review-b.md
@@ -1,0 +1,26 @@
+# 方案审计 B：工程迁移与归档
+
+日期：2026-09-05
+对象：docs/internal/maintenance-20260905-plan.md v1.1
+源码基线：1de31845cce25126651231d51047564eb055e1da
+载体：本会话 ChatGPT 自身第二轮；与 A 分开检查工程风险，不声明不同模型或认知隔离。
+
+## 审计问题
+
+重构能否维持事务、来源和公共调用边界？归档是否保留真实恢复路径？工作包的交付状态能否被核对？
+
+## 检查与发现
+
+1. runtime-manifest.json 当前只列出原大文件和适配器。抽取的实际实现模块必须同步进入 required_scripts/fingerprint_files；删除模块应阻断，修改应改变指纹。禁止用“行为没变”绕过旧 Mission 的来源不匹配。
+2. tplan_runtime.read_mission 在锁内恢复 pending transaction，不能直接当作无副作用 query 提取。一个锁和一个错误类型保持，事务簇最后处理；纯函数、schema、展示优先。
+3. SRA 原 facade 的星号导出形成真实消费者耦合。先确认实际 imports，保持公共入口，再逐片显式内部导入；禁止模块回导 facade 或复制函数制造两份 owner。迁移后的故障注入应打到实际 owner。
+4. #145 要求先清单和恢复复核再删除。v1.9.1 release commit 是已有不变恢复源；必须固定完整 SHA、树及 blob。只删 HEAD 不减历史 clone 体积，收益限于检索和维护。报告、污染证据、汇总和材料性 redline 默认保留。
+5. 默认 CI 不应为验证归档自动获取全量历史日志。清单的生成/复核与普通离线测试分开；引用包括代码块和程序路径，不能只扫 Markdown link。
+6. 测试大量退役与对应高风险实现搬迁不能同一 PR；阶段分别提交。若本轮只完成一个拆分片，issue 保留其余复选项，不声明整项已完成。
+7. 发版、重写历史、修改旧审计结论不在授权范围。需要新记录说明当前结果，而不是把旧 PASS 改写成新验证。
+
+## 结论
+
+v1.1 的分阶段约束覆盖上述工程风险，允许创建 issue 并依次实施。#145 的删除 gate 仍需对具体 inventory、恢复结果和引用解析复核，不由方案 PASS 自动替代。
+
+Verdict: PASS for staged implementation; archive deletion requires its own evidence gate.

--- a/docs/internal/maintenance-20260905-plan.md
+++ b/docs/internal/maintenance-20260905-plan.md
@@ -1,0 +1,54 @@
+# 合同修复与维护优化：执行方案 v1.1
+
+日期：2026-09-05
+计划：mindthus-maintenance-20260905
+基线：1de31845cce25126651231d51047564eb055e1da
+
+## 授权与范围
+
+用户批准：修复 SRA 依赖授权和结构合同；清理重复/过期测试；按职责拆分 SRA、TPlan 大脚本；归档历史基准逐调用材料。用户本轮明确使用 ChatGPT 自身开展两轮审计，不要求额外 CLI 或独立模型。审计如实标记为同一 ChatGPT 的两个审查阶段，不声明认知隔离或外部模型通过。
+
+本轮创建并维护 issue，按事项提交与验证。代码合并仍须满足各项出口。版本、发布、业务效果研究、路由改造和 Git 历史重写均不在本轮范围。
+
+## 顺序与工作包
+
+| 标识 | 工作 | 出口 |
+|---|---|---|
+| C01 | SRA 同一输出 Schema 驱动接收结构检查 | 根/嵌套未知字段、缺失、类型、分支被正确拒绝；有效模板通过；拒绝无写入 |
+| C02 | 依赖满足与授权 | 未满足前置阻断立即投入；已完成前置零投入合法；多级依赖和两视图别名一致 |
+| M01 | 测试清理两波 | 逐项台账含旧断言、保护对象、替代 owner、失效变体验证；不按数量达标 |
+| M02 | SRA 按职责抽取 | schema/结构、依赖、比较/投影、carrier 与核心解耦；公共入口不变 |
+| M03 | TPlan 分片拆分 | 先纯函数和展示，后 provenance；事务/锁/权限最后处理，不与大批退役混合 |
+| #145 | 历史逐调用材料归档 | 先 inventory-only、恢复和引用复核，后批准集合迁出 HEAD |
+
+缺陷、纯重构、退役、归档各自独立提交，不能以一个整体 PASS 掩盖未完成工作包。模块拆分允许按片交付并在 issue 中保留余项。
+
+## C01 唯一结构合同
+
+复用当前 SRA 输出 Schema，以有界的标准库结构解释器校验当前使用的 object/array/type/required/properties/const/enum/oneOf/anyOf/not/长度/范围/唯一性/pattern 关键字。未知 Schema 关键字使检查失败；不声称实现完整 Draft-07。结构不合法先返回，领域检查随后执行。Coverage/Challenge/Situated/Reconciliation 使用相同入口，record/check/repair 经现有 validator 复用。Workflow final 保持从已校验 judgment 确定性重建。无未知字段自动丢弃或静默纠正。
+
+## C02 依赖语义
+
+依赖边只来自 packet 的 depends_on。每条边的判断记录绑定 dependent/prerequisite、状态、证据和理由。初始支持 satisfied、unmet、unknown；satisfied 必须有 packet 中的证据引用。引用存在仅证明引用合法，语义满足仍由 Agentic 审查负责。替代或豁免不能由 Agent 随便填字符串获得权限；本轮不新增通用 waiver 控制通道，来源若未在合法输入中消除原硬前置，按 unmet/unknown 处理。
+
+当前资源和立即下一批次的每个候选，其硬前置都需要已满足；把前置选入 Bundle 不是完成证据。已满足的前置可以没有当前投入。前置未满足时可以先投前置，或为后续给 conditional 并明确启动条件。没有依赖的既有 v0.3 判断结构不变；有依赖但缺少解析记录的旧判断只能诊断为不足，需从来源准备新 run，Repair 不补造权威。
+
+新解析字段进入 Challenge 别名转换、比较和 reconciliation 证据集合。依赖图检查按已满足边截断，避免把已完成历史链误判为当前死锁。未满足闭环不能产生立即授权。
+
+## M01 测试
+
+保留既有 lifecycle registry。旧测试需有可核对的不变量与替代覆盖；表格参数化保留案例标识和失败定位。当前 CI 数量与静态 test_* 数量分别报告。事务、隐私、权限、数据损失、恢复和已知缺陷回归不按年龄清理。第一波只收敛明确重复的静态/打包断言，第二波整理拆分后的 owner。测试数和耗时是观测，不是删除目标。
+
+## M02/M03 拆分约束
+
+一个错误类型、一个锁、一个事务 owner。纯函数先提取，保留实际公共 import 入口；内部依赖明确，不用复制实现或循环回导制造小文件。代码移动和行为修复分开。测试需确认 fault injection 命中新 owner。TPlan read_mission 的锁内恢复仍归持久化。新实现模块加入 required_scripts 与 fingerprint_files，并验证丢失/篡改检测。物理拆分会改变 fingerprint，不能为旧 Mission 绕过现有 provenance 检查。
+
+## #145 归档
+
+复用 issue #145。源钉住 v1.9.1 peeled commit d735d11c14d92325607fe6b844eb29f7c426df62。范围 docs/benchmarks/runs/；原统计 6493 文件，逐调用候选 6241，报告/汇总等至少保留 202，50 个 judge-output-schema 默认保留。
+
+先形成可重放的逐文件清单（path/blob/bytes/disposition/reason/recovery ref），核对依赖它们的报告、测试、脚本。材料性例外默认保留。完整 source tree OID 可作为清单来源锚点，但不能只给一条“去历史找”的模糊说明。新临时目录真实恢复比对后才删已批准集合。引用既包括 Markdown 链接，也包括 code block 和程序路径。当前 CI 不依赖联网拉历史材料。保留所有旧 commit，禁止 filter-repo/force push/移动已发 tag。
+
+## 出口
+
+每个工作包：基线、复现/保护、实现、定向复审、聚焦测试、全套 unittest、lifecycle、全布局打包、diff 检查、独立提交、issue 状态更新。使用已验证的 Python 3.10+ 解释器，分别报告执行/通过/跳过。外部模型和宿主实测未运行就不声明。

--- a/skills/sra/resources/context-isolation.md
+++ b/skills/sra/resources/context-isolation.md
@@ -445,6 +445,15 @@ truth. Conflict selects no winner and opens one targeted reconciliation.
 The human-readable renderer follows this table. A blocked or infeasible result never says
 that work may start immediately.
 
+## Structural Reception Contract
+
+Every Agentic judgment is checked against the same packet-specific output schema that
+is supplied to its carrier. The bounded `sra_structure.py` interpreter supports the
+keywords used by these schemas and rejects unsupported schema vocabulary. Closed objects,
+required fields, JSON types and variant constraints are checked before domain invariants
+and before any judgment is recorded. It is not a general Draft-07 implementation.
+Workflow final decisions remain deterministic projections of validated judgments.
+
 ## Deterministic Integrity
 
 `run.json` is a cache, not independent authority. `check_sra_run.py` reconstructs from:

--- a/skills/sra/scripts/sra_runtime_core.py
+++ b/skills/sra/scripts/sra_runtime_core.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from sra_domain import *  # noqa: F403
+from sra_structure import validate_structure
 
 RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{2,63}$")
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{1,63}$")
@@ -1610,6 +1611,9 @@ def validate_coverage_judgment(
     findings: list[str] = []
     if not isinstance(judgment, dict):
         return ["coverage judgment must be an object"]
+    structural = validate_structure(judgment, coverage_output_schema(packet), "coverage_judgment")
+    if structural:
+        return structural
     if judgment.get("schema_version") != COVERAGE_JUDGMENT_SCHEMA:  # noqa: F405
         findings.append(f"schema_version must be {COVERAGE_JUDGMENT_SCHEMA}")
     if judgment.get("stage") != "coverage":
@@ -2019,6 +2023,17 @@ def _validate_decision_judgment(
     findings: list[str] = []
     if not isinstance(judgment, dict):
         return [f"{stage} judgment must be an object"]
+    structural = validate_structure(
+        judgment,
+        _decision_output_schema(
+            packet=packet, title=f"SRA {stage} judgment", schema_version=schema_version,
+            stage=stage, id_field=id_field, outcomes=allowed_outcomes,
+            require_state=require_state, require_conflict_resolutions=stage == "reconciliation",
+        ),
+        f"{stage}_judgment",
+    )
+    if structural:
+        return structural
     if judgment.get("schema_version") != schema_version:
         findings.append(f"schema_version must be {schema_version}")
     if judgment.get("stage") != stage:
@@ -2491,7 +2506,7 @@ def validate_reconciliation_judgment(
         allowed_outcomes=RECONCILIATION_OUTCOMES,  # noqa: F405
         require_state=True,
     )
-    if not isinstance(judgment, dict):
+    if findings or not isinstance(judgment, dict):
         return findings
     conflict_fields = {item["field"] for item in packet.get("conflict_fields", [])}
     resolutions = judgment.get("conflict_resolutions")

--- a/skills/sra/scripts/sra_structure.py
+++ b/skills/sra/scripts/sra_structure.py
@@ -1,0 +1,127 @@
+"""Validate the bounded Schema vocabulary emitted by SRA, using that same schema.
+
+This is deliberately not a general JSON Schema implementation. Unsupported schema
+keywords fail closed even in branches that the current instance does not exercise.
+Semantic resource and authorization rules remain in the domain validators.
+"""
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+KEYWORDS = frozenset({
+    "$schema", "title", "description", "type", "properties", "required",
+    "additionalProperties", "items", "minItems", "maxItems", "uniqueItems",
+    "const", "enum", "oneOf", "anyOf", "not", "minLength", "maxLength",
+    "pattern", "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum",
+})
+TYPES = {"object", "array", "string", "boolean", "number", "integer", "null"}
+
+
+def _equal(left: Any, right: Any) -> bool:
+    if isinstance(left, bool) or isinstance(right, bool):
+        return type(left) is type(right) and left == right
+    if isinstance(left, dict) and isinstance(right, dict):
+        return left.keys() == right.keys() and all(_equal(left[k], right[k]) for k in left)
+    if isinstance(left, list) and isinstance(right, list):
+        return len(left) == len(right) and all(_equal(a, b) for a, b in zip(left, right))
+    return left == right
+
+
+def schema_findings(schema: Any, path: str = "schema") -> list[str]:
+    if not isinstance(schema, dict):
+        return [f"{path} must be a supported schema object"]
+    errors = [f"{path}: unsupported schema keyword {key}" for key in sorted(set(schema) - KEYWORDS)]
+    if "type" in schema and (not isinstance(schema["type"], str) or schema["type"] not in TYPES):
+        errors.append(f"{path}: unsupported schema type")
+    for key in ("properties",):
+        if key in schema:
+            if not isinstance(schema[key], dict):
+                errors.append(f"{path}.{key} must be an object")
+            else:
+                for name, child in schema[key].items():
+                    errors.extend(schema_findings(child, f"{path}.{key}.{name}"))
+    for key in ("items", "not"):
+        if key in schema:
+            errors.extend(schema_findings(schema[key], f"{path}.{key}"))
+    for key in ("oneOf", "anyOf"):
+        if key in schema:
+            choices = schema[key]
+            if not isinstance(choices, list) or not choices:
+                errors.append(f"{path}.{key} must contain schema variants")
+            else:
+                for index, child in enumerate(choices):
+                    errors.extend(schema_findings(child, f"{path}.{key}[{index}]"))
+    if "additionalProperties" in schema and not isinstance(schema["additionalProperties"], bool):
+        errors.append(f"{path}: only boolean additionalProperties is supported")
+    return errors
+
+
+def _instance_findings(value: Any, schema: dict[str, Any], path: str) -> list[str]:
+    errors: list[str] = []
+    for branch in ("oneOf", "anyOf"):
+        if branch not in schema:
+            continue
+        reports = [_instance_findings(value, variant, path) for variant in schema[branch]]
+        matches = sum(not report for report in reports)
+        if (branch == "oneOf" and matches != 1) or (branch == "anyOf" and matches == 0):
+            errors.append(f"{path}: {branch} requires {'exactly one' if branch == 'oneOf' else 'a'} valid variant")
+            if reports:
+                errors.extend(min(reports, key=len))
+    if "not" in schema and not _instance_findings(value, schema["not"], path):
+        errors.append(f"{path}: value uses a reserved or excluded variant")
+    expected = schema.get("type")
+    numeric = isinstance(value, (int, float)) and not isinstance(value, bool)
+    finite = numeric and (isinstance(value, int) or math.isfinite(value))
+    valid_type = {
+        "object": isinstance(value, dict), "array": isinstance(value, list),
+        "string": isinstance(value, str), "boolean": isinstance(value, bool),
+        "number": finite, "integer": finite and value == int(value),
+        "null": value is None,
+    }
+    if expected is not None and not valid_type[expected]:
+        return errors + [f"{path} must be {expected} (numbers must be finite; bool is not a number)"]
+    if "const" in schema and not _equal(value, schema["const"]):
+        constant = str(schema["const"]).lower() if isinstance(schema["const"], bool) else repr(schema["const"])
+        errors.append(f"{path} must be {constant}")
+    if "enum" in schema and not any(_equal(value, allowed) for allowed in schema["enum"]):
+        errors.append(f"{path} contains an unsupported enum value: {value!r}")
+    if isinstance(value, dict):
+        props = schema.get("properties", {})
+        for key in schema.get("required", []):
+            if key not in value:
+                errors.append(f"{path}.{key} is a required field")
+        if schema.get("additionalProperties") is False:
+            for key in sorted(set(value) - set(props)):
+                errors.append(f"{path}.{key} is an unsupported field")
+        for key in value.keys() & props.keys():
+            errors.extend(_instance_findings(value[key], props[key], f"{path}.{key}"))
+    elif isinstance(value, list):
+        for keyword, predicate in (("minItems", lambda n: len(value) >= n), ("maxItems", lambda n: len(value) <= n)):
+            if keyword in schema and not predicate(schema[keyword]):
+                errors.append(f"{path} violates {keyword}={schema[keyword]}")
+        if schema.get("uniqueItems") and any(_equal(value[i], value[j]) for i in range(len(value)) for j in range(i)):
+            errors.append(f"{path} contains duplicate items")
+        if "items" in schema:
+            for index, item in enumerate(value):
+                errors.extend(_instance_findings(item, schema["items"], f"{path}[{index}]"))
+    elif isinstance(value, str):
+        if len(value) < schema.get("minLength", 0):
+            errors.append(f"{path} must be a non-empty string of the required length")
+        if "maxLength" in schema and len(value) > schema["maxLength"]:
+            errors.append(f"{path} exceeds maxLength")
+        if "pattern" in schema and re.search(schema["pattern"], value) is None:
+            errors.append(f"{path} does not match pattern")
+    elif finite:
+        for key, valid in (("minimum", lambda n: value >= n), ("maximum", lambda n: value <= n),
+                           ("exclusiveMinimum", lambda n: value > n), ("exclusiveMaximum", lambda n: value < n)):
+            if key in schema and not valid(schema[key]):
+                errors.append(f"{path} violates {key}={schema[key]}")
+    return errors
+
+
+def validate_structure(value: Any, schema: dict[str, Any], path: str = "judgment") -> list[str]:
+    """Return shape findings without mutating either the value or its schema."""
+    errors = schema_findings(schema)
+    return errors or _instance_findings(value, schema, path)

--- a/tests/test_sra_v03_runtime_contract.py
+++ b/tests/test_sra_v03_runtime_contract.py
@@ -389,6 +389,53 @@ class SraV03RuntimeContractTests(unittest.TestCase):
             bundle_schema["properties"]["bundle_assessments"]["minItems"], 1
         )
 
+    def test_schema_vocabulary_and_json_type_boundaries(self):
+        from sra_structure import validate_structure
+        probes = [
+            (True, {"type": "number"}),
+            (True, {"enum": [1]}),
+            (float("nan"), {"type": "number"}),
+            (float("inf"), {"type": "number"}),
+            ({}, {"type": "object", "properties": {"unused": {"unsupportedKeyword": True}}}),
+            ([], {"type": ["array", "null"]}),
+            ("x", {"oneOf": [{"type": "string"}, {"type": "string"}]}),
+            ([1, 1.0], {"type": "array", "uniqueItems": True}),
+        ]
+        for value, schema in probes:
+            with self.subTest(value=value, schema=schema):
+                self.assertTrue(validate_structure(value, schema))
+        self.assertEqual(validate_structure([True, 1], {"type": "array", "uniqueItems": True}), [])
+        self.assertEqual(validate_structure(1.0, {"type": "integer"}), [])
+
+    def test_closed_schema_rejects_unknown_fields_at_each_object_boundary(self):
+        packet = build_packets(input_data(mode="full"))["situated_packet"]
+        paths = [(), ("allocation_ledger", 0), ("candidate_assessments", 0),
+                 ("next_tranche",), ("reserve",), ("bundle_decision",),
+                 ("bundle_decision", "bundle_assessments", 0),
+                 ("next_tranche", "resource_allocations", 0, "quantity")]
+        for path in paths:
+            with self.subTest(path=path):
+                judgment = situated_judgment(packet)
+                target = judgment
+                for key in path:
+                    target = target[key]
+                target["unrecognized_authorization_override"] = True
+                findings = validate_situated_judgment(judgment, packet)
+                self.assertTrue(any("unrecognized_authorization_override" in x for x in findings), findings)
+
+    def test_closed_schema_rejects_missing_and_malformed_nested_fields(self):
+        packet = build_packets(input_data())["situated_packet"]
+        for field in ("evidence_refs", "assumption_refs", "missing_information"):
+            with self.subTest(missing=field):
+                judgment = situated_judgment(packet)
+                del judgment[field]
+                self.assertTrue(validate_situated_judgment(judgment, packet))
+        for value in (None, "not-an-object", [], True):
+            with self.subTest(tranche=value):
+                judgment = situated_judgment(packet)
+                judgment["next_tranche"] = value
+                self.assertTrue(validate_situated_judgment(judgment, packet))
+
     def test_valid_full_bundle_judgment_passes(self):
         packet = build_packets(input_data(mode="full"))["situated_packet"]
         self.assertEqual(validate_situated_judgment(situated_judgment(packet), packet), [])

--- a/tests/test_sra_v03_runtime_lifecycle.py
+++ b/tests/test_sra_v03_runtime_lifecycle.py
@@ -44,6 +44,24 @@ class SraV03RuntimeLifecycleTests(unittest.TestCase):
         prepare(input_path, run_dir)
         return run_dir
 
+    def test_invalid_judgment_structure_leaves_run_byte_identical(self):
+        data = input_data()
+        data["contamination_signals"] = []
+        run_dir = self.prepare_run(data)
+        packet = load_json(run_dir / "situated-packet.json")
+        before = {str(p.relative_to(run_dir)): p.read_bytes() for p in run_dir.rglob("*") if p.is_file()}
+        for field in ("unrecognized_authorization_override", "next_tranche"):
+            with self.subTest(field=field):
+                judgment = situated_judgment(packet)
+                if field == "next_tranche":
+                    judgment[field]["undeclared"] = "value"
+                else:
+                    judgment[field] = True
+                with self.assertRaises(SraRuntimeError):
+                    record_situated(run_dir, judgment, carrier="packet_bound", receipt_path=None)
+                after = {str(p.relative_to(run_dir)): p.read_bytes() for p in run_dir.rglob("*") if p.is_file()}
+                self.assertEqual(after, before)
+
     def test_fresh_prepared_run_checks_cleanly(self):
         run_dir = self.prepare_run()
         report = run_check(run_dir)


### PR DESCRIPTION
Closes #168. Parent #167.

Two user-authorized ChatGPT self-reviews are recorded, not external model reviews. Canonical generated output schemas now also validate coverage/challenge/situated/reconciliation reception before writes. Unknown schema vocabulary fails closed.

Baseline new counterexamples failed; fixed focused 124 tests pass. Full suite ran 1026: 1021 passed, 5 optional skips (Python 3.10.12). Lifecycle 76/76. All five layouts include sra_structure.py. Invalid-reception snapshot tests preserve every run byte. No release, tag, TPlan or archive mutation.