### PR TITLE
fix(sra): prerequisite evidence before resource authorization

### DIFF
--- a/skills/sra/resources/context-isolation.md
+++ b/skills/sra/resources/context-isolation.md
@@ -193,6 +193,26 @@ next tranche is one cumulative commitment for the decision window and must remai
 that demand. Ordinal levels and indivisible blocks remain within the same declared
 candidate boundary.
 
+### Dependency Authorization
+
+`depends_on` records hard prerequisites. When the packet contains dependency edges,
+every judgment includes `dependency_resolutions`, one record per edge:
+`dependent_id`, `prerequisite_id`, `status`, `evidence_refs`, and `reason`.
+`status` is `satisfied`, `unmet`, or `unknown`. Satisfied edges cite evidence already
+bound to the prerequisite candidate. Reference checks do not prove semantic completion.
+
+Current allocations and immediately authorized next tranches require satisfied
+prerequisites. Selecting a prerequisite in a bundle is planning, not completion. A
+satisfied prerequisite may receive zero new resources. An unresolved prerequisite can
+be executed first; a successor may instead be conditional on named completion evidence.
+Unresolved cycles cannot define an executable selected path. Satisfied edges stop
+traversal, so completed historical cycles do not create false deadlocks.
+
+No-dependency v0.3 inputs retain their existing shape. Dependency-bearing old judgments
+without resolutions are insufficient for new authorization; prepare a new run from source
+evidence. Repair never adds dependency evidence or rewrites old Agentic judgments.
+This contract does not add a self-issued waiver/permission channel.
+
 ### Evidence
 
 Every evidence item records:

--- a/skills/sra/scripts/sra_dependencies.py
+++ b/skills/sra/scripts/sra_dependencies.py
@@ -1,0 +1,117 @@
+"""SRA dependency evidence and deterministic authorization consequences.
+
+The packet owns the graph. Agentic judgments assess its edges; this module checks
+those declarations, not the semantic truth of evidence or the best allocation.
+"""
+from __future__ import annotations
+from typing import Any
+
+
+def dependency_edges(packet: dict[str, Any], id_field: str) -> set[tuple[str, str]]:
+    return {(str(c[id_field]), str(p)) for c in packet.get("candidates", [])
+            for p in c.get("depends_on", [])}
+
+
+def dependency_resolution_schema(packet: dict[str, Any], id_field: str) -> dict[str, Any]:
+    ids = [c[id_field] for c in packet.get("candidates", [])]
+    evidence = [e["evidence_id"] for e in packet.get("evidence", [])]
+    return {
+        "type": "array", "minItems": len(dependency_edges(packet, id_field)),
+        "maxItems": len(dependency_edges(packet, id_field)),
+        "description": (
+            "Resolve every packet depends_on edge once. satisfied cites evidence bound to "
+            "the prerequisite; unmet/unknown prevents immediate current or next allocation "
+            "to its dependent. Inclusion in a bundle is not completion."
+        ),
+        "items": {
+            "type": "object", "additionalProperties": False,
+            "required": ["dependent_id", "prerequisite_id", "status", "evidence_refs", "reason"],
+            "properties": {
+                "dependent_id": {"type": "string", "enum": ids},
+                "prerequisite_id": {"type": "string", "enum": ids},
+                "status": {"type": "string", "enum": ["satisfied", "unmet", "unknown"]},
+                "evidence_refs": {"type": "array", "uniqueItems": True,
+                                  "items": {"type": "string", "enum": evidence}},
+                "reason": {"type": "string", "minLength": 1},
+            },
+        },
+    }
+
+
+def validate_dependencies(judgment: dict[str, Any], packet: dict[str, Any], id_field: str) -> list[str]:
+    """Run after structural validation; return domain errors without mutations."""
+    edges = dependency_edges(packet, id_field)
+    if not edges:
+        return []
+    errors: list[str] = []
+    candidates = {str(c[id_field]): c for c in packet["candidates"]}
+    resolutions: dict[tuple[str, str], dict[str, Any]] = {}
+    for record in judgment["dependency_resolutions"]:
+        edge = (record["dependent_id"], record["prerequisite_id"])
+        if edge not in edges:
+            errors.append(f"dependency resolution {edge} does not reference a packet edge")
+        if edge in resolutions:
+            errors.append(f"duplicate dependency resolution {edge}")
+        resolutions[edge] = record
+        bound_evidence = set(candidates.get(edge[1], {}).get("evidence_refs", []))
+        cited = set(record["evidence_refs"])
+        if not cited <= bound_evidence:
+            errors.append(f"dependency {edge} evidence must be bound to its prerequisite candidate")
+        if record["status"] == "satisfied" and not cited:
+            errors.append(f"satisfied dependency {edge} requires prerequisite evidence")
+    if set(resolutions) != edges:
+        errors.append("dependency_resolutions must cover every packet dependency exactly once")
+    if errors:
+        return errors
+
+    active = {str(row[id_field]) for row in judgment["allocation_ledger"] if row["current_allocations"]}
+    target = judgment["next_tranche"]["target_id"]
+    outcome = judgment["allocation_outcome"]
+    if outcome == "allocate" and target in candidates:
+        active.add(target)
+    unresolved: dict[str, list[str]] = {}
+    for (dependent, prerequisite), record in resolutions.items():
+        if record["status"] != "satisfied":
+            unresolved.setdefault(dependent, []).append(prerequisite)
+            if dependent in active:
+                errors.append(
+                    f"candidate {dependent} has {record['status']} dependency {prerequisite}; "
+                    "immediate allocation requires satisfied prerequisites"
+                )
+
+    bundle = judgment.get("bundle_decision", {})
+    selected = next((b for b in bundle.get("bundle_assessments", [])
+                     if b["bundle_id"] == bundle.get("selected_bundle_id")), None)
+    members = set(selected["member_ids"]) if selected else set()
+    if outcome == "allocate":
+        for dependent in members:
+            for prerequisite in unresolved.get(dependent, []):
+                if prerequisite not in members:
+                    errors.append(
+                        f"selected bundle omits unresolved dependency {prerequisite} of {dependent}"
+                    )
+
+    # Completed edges stop traversal: historical cycles are not current deadlocks.
+    def cycle_from(node: str, stack: tuple[str, ...], done: set[str]) -> bool:
+        if node in stack:
+            return True
+        if node in done:
+            return False
+        if any(cycle_from(p, stack + (node,), done) for p in unresolved.get(node, [])):
+            return True
+        done.add(node)
+        return False
+
+    if outcome in {"allocate", "conditional"}:
+        roots = active | members | ({target} if target in candidates else set())
+        if any(cycle_from(root, (), set()) for root in roots):
+            errors.append("unresolved dependency cycle prevents an executable selected path")
+    return errors
+
+
+def normalized_dependency_resolutions(judgment: dict[str, Any], mapping: dict[str, str]) -> list[dict[str, Any]]:
+    values = [{"dependent_id": mapping.get(r["dependent_id"], r["dependent_id"]),
+               "prerequisite_id": mapping.get(r["prerequisite_id"], r["prerequisite_id"]),
+               "status": r["status"], "evidence_refs": sorted(r["evidence_refs"])}
+              for r in judgment.get("dependency_resolutions", [])]
+    return sorted(values, key=lambda r: (r["dependent_id"], r["prerequisite_id"]))

--- a/skills/sra/scripts/sra_domain.py
+++ b/skills/sra/scripts/sra_domain.py
@@ -135,7 +135,7 @@ STATE_REF_KINDS_BY_CONSIDERATION = {
 COMPARISON_FIELDS = (
     "allocation_outcome", "candidate_assessments", "bundle_decision", "allocation_ledger",
     "next_tranche", "investment_ceiling", "authorization_horizon", "reserve",
-    "missing_information",
+    "missing_information", "dependency_resolutions",
 )
 OVERRIDE_FIELDS = (
     "override_reason", "approved_by", "authority_ref", "risk_acceptance_scope",

--- a/skills/sra/scripts/sra_runtime_core.py
+++ b/skills/sra/scripts/sra_runtime_core.py
@@ -13,6 +13,10 @@ from typing import Any, Iterable
 
 from sra_domain import *  # noqa: F403
 from sra_structure import validate_structure
+from sra_dependencies import (
+    dependency_edges, dependency_resolution_schema, validate_dependencies,
+    normalized_dependency_resolutions,
+)
 
 RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{2,63}$")
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{1,63}$")
@@ -1532,6 +1536,9 @@ def _decision_output_schema(
         "stage": {"type": "string", "const": stage},
         "packet_hash": {"type": "string", "const": packet["packet_hash"]},
     })
+    if dependency_edges(packet, id_field):
+        required.append("dependency_resolutions")
+        props["dependency_resolutions"] = dependency_resolution_schema(packet, id_field)
     if require_conflict_resolutions:
         state_ids = [item["state_id"] for item in packet.get("state_items", [])]
         props["conflict_resolutions"] = {
@@ -2100,6 +2107,8 @@ def _validate_decision_judgment(
         findings.append(
             "candidate_assessments must cover every packet candidate exactly once"
         )
+
+    findings.extend(validate_dependencies(judgment, packet, id_field))
 
     selected_bundle_members = _validate_bundle_decision(
         judgment,
@@ -2689,6 +2698,8 @@ def normalized_decision_core(
             "review_time": reserve.get("review_time"),
         },
         "missing_information": sorted(missing) if isinstance(missing, list) else [repr(missing)],
+        **({"dependency_resolutions": normalized_dependency_resolutions(judgment, mapping)}
+           if "dependency_resolutions" in judgment else {}),
     }
 
 
@@ -2755,6 +2766,8 @@ def build_reconciliation_packet(
     )
     state_ids = set(situated_judgment.get("state_refs", []))
     for judgment in (challenge_judgment, situated_judgment):
+        for resolution in judgment.get("dependency_resolutions", []):
+            evidence_ids.update(resolution.get("evidence_refs", []))
         for assessment in judgment.get("candidate_assessments", []):
             if not isinstance(assessment, dict):
                 continue

--- a/tests/test_sra_v03_runtime_contract.py
+++ b/tests/test_sra_v03_runtime_contract.py
@@ -298,6 +298,9 @@ def challenge_from_situated(challenge_packet: dict, situated: dict, mapping: dic
     ]
     for bundle in result["bundle_decision"]["bundle_assessments"]:
         bundle["member_ids"] = [original_to_alias[item] for item in bundle["member_ids"]]
+    for resolution in result.get("dependency_resolutions", []):
+        for field in ("dependent_id", "prerequisite_id"):
+            resolution[field] = original_to_alias[resolution[field]]
     return result
 
 
@@ -388,6 +391,124 @@ class SraV03RuntimeContractTests(unittest.TestCase):
         self.assertGreaterEqual(
             bundle_schema["properties"]["bundle_assessments"]["minItems"], 1
         )
+
+    def test_immediate_allocation_requires_dependency_resolution(self):
+        data = input_data(mode="full")
+        data["candidates"][1]["depends_on"] = ["page-polish"]
+        packet = build_packets(data)["situated_packet"]
+        judgment = situated_judgment(packet)
+        judgment["allocation_ledger"][0]["posture"] = "stop"
+        self.assertTrue(validate_situated_judgment(judgment, packet))
+
+    def test_dependency_authorization_truth_table(self):
+        for mode in ("lite", "full"):
+            for status, refs, allowed in (("satisfied", ["E-page"], True),
+                                           ("satisfied", [], False),
+                                           ("satisfied", ["E-payment"], False),
+                                           ("unmet", [], False), ("unknown", [], False)):
+                with self.subTest(mode=mode, status=status, refs=refs):
+                    data = input_data(mode=mode)
+                    data["candidates"][1]["depends_on"] = ["page-polish"]
+                    packet = build_packets(data)["situated_packet"]
+                    judgment = situated_judgment(packet)
+                    judgment["allocation_ledger"][0]["posture"] = "stop"
+                    judgment["dependency_resolutions"] = [{
+                        "dependent_id": "payment-validation", "prerequisite_id": "page-polish",
+                        "status": status, "evidence_refs": refs,
+                        "reason": "Explicit assessment of the prerequisite evidence.",
+                    }]
+                    findings = validate_situated_judgment(judgment, packet)
+                    self.assertEqual(not findings, allowed, findings)
+
+    def test_unmet_dependency_allows_predecessor_first_and_conditional_successor(self):
+        data = input_data()
+        data["candidates"][1]["depends_on"] = ["page-polish"]
+        packet = build_packets(data)["situated_packet"]
+        judgment = situated_judgment(packet)
+        judgment["dependency_resolutions"] = [{
+            "dependent_id": "payment-validation", "prerequisite_id": "page-polish",
+            "status": "unmet", "evidence_refs": [], "reason": "Prerequisite has not completed.",
+        }]
+        judgment["next_tranche"]["target_id"] = "page-polish"
+        judgment["allocation_ledger"][0]["posture"] = "candidate"
+        self.assertEqual(validate_situated_judgment(judgment, packet), [])
+        judgment["next_tranche"]["target_id"] = "payment-validation"
+        judgment["allocation_outcome"] = "conditional"
+        judgment["next_tranche"]["start_condition"] = "Start only after page prerequisite evidence is accepted."
+        self.assertEqual(validate_situated_judgment(judgment, packet), [])
+
+    def test_dependency_current_allocation_and_selected_bundle_do_not_imply_completion(self):
+        data = input_data(mode="full")
+        data["candidates"][1]["depends_on"] = ["page-polish"]
+        packet = build_packets(data)["situated_packet"]
+        judgment = situated_judgment(packet)
+        judgment["dependency_resolutions"] = [{
+            "dependent_id": "payment-validation", "prerequisite_id": "page-polish",
+            "status": "unknown", "evidence_refs": [], "reason": "No completion evidence.",
+        }]
+        judgment["bundle_decision"]["bundle_assessments"][0]["member_ids"].append("page-polish")
+        judgment["allocation_ledger"][0]["posture"] = "candidate"
+        self.assertTrue(any("immediate allocation" in x for x in validate_situated_judgment(judgment, packet)))
+        judgment["next_tranche"]["target_id"] = "page-polish"
+        judgment["next_tranche"]["resource_allocations"] = [allocation("engineer-time", 0.8)]
+        judgment["allocation_ledger"][1].update(posture="floor", current_allocations=[allocation("engineer-time", 0.1)])
+        self.assertTrue(any("immediate allocation" in x for x in validate_situated_judgment(judgment, packet)))
+
+    def test_multilevel_dependencies_authorize_only_the_ready_frontier(self):
+        data = input_data()
+        prerequisite = copy.deepcopy(data["candidates"][0])
+        prerequisite["candidate_id"] = "readiness-check"
+        data["candidates"].append(prerequisite)
+        data["candidates"][0]["depends_on"] = ["readiness-check"]
+        data["candidates"][1]["depends_on"] = ["page-polish"]
+        packet = build_packets(data)["situated_packet"]
+        judgment = situated_judgment(packet)
+        judgment["candidate_assessments"].append(assessment("readiness-check"))
+        judgment["allocation_ledger"].append({"candidate_id": "readiness-check", "posture": "candidate", "current_allocations": [], "reason": "Ready predecessor."})
+        judgment["allocation_ledger"][0]["posture"] = "candidate"
+        judgment["dependency_resolutions"] = [
+            {"dependent_id": a, "prerequisite_id": b, "status": "unmet", "evidence_refs": [], "reason": "Pending predecessor."}
+            for a, b in (("payment-validation", "page-polish"), ("page-polish", "readiness-check"))]
+        for target, allowed in (("payment-validation", False), ("page-polish", False), ("readiness-check", True)):
+            with self.subTest(target=target):
+                judgment["next_tranche"]["target_id"] = target
+                findings = validate_situated_judgment(judgment, packet)
+                self.assertEqual(not findings, allowed, findings)
+        judgment["dependency_resolutions"][1] = copy.deepcopy(judgment["dependency_resolutions"][0])
+        self.assertTrue(any("dependency" in x for x in validate_situated_judgment(judgment, packet)))
+
+    def test_dependency_alias_comparison_and_unmet_cycles(self):
+        from sra_runtime import validate_challenge_judgment
+        data = input_data()
+        data["candidates"][1]["depends_on"] = ["page-polish"]
+        built = build_packets(data)
+        situated = situated_judgment(built["situated_packet"])
+        situated["dependency_resolutions"] = [{
+            "dependent_id": "payment-validation", "prerequisite_id": "page-polish",
+            "status": "satisfied", "evidence_refs": ["E-page"], "reason": "Existing capability is accepted.",
+        }]
+        challenge = challenge_from_situated(built["challenge_packet"], situated, built["challenge_map"])
+        self.assertEqual(validate_challenge_judgment(challenge, built["challenge_packet"]), [])
+        def compare():
+            return compare_views(run_id=data["run_id"], challenge_packet_hash=built["challenge_packet"]["packet_hash"],
+                                 situated_packet_hash=built["situated_packet"]["packet_hash"],
+                                 challenge_judgment=challenge, situated_judgment=situated, challenge_map=built["challenge_map"])
+        self.assertEqual(compare()["status"], "agree")
+        challenge["dependency_resolutions"][0]["status"] = "unknown"
+        self.assertIn("dependency_resolutions", [x["field"] for x in compare()["conflict_fields"]])
+        data["candidates"][0]["depends_on"] = ["payment-validation"]
+        packet = build_packets(data)["situated_packet"]
+        judgment = situated_judgment(packet)
+        judgment["allocation_outcome"] = "conditional"
+        judgment["next_tranche"]["start_condition"] = "After both prerequisites."
+        judgment["dependency_resolutions"] = [
+            {"dependent_id": a, "prerequisite_id": b, "status": "unmet", "evidence_refs": [], "reason": "Pending."}
+            for a, b in (("payment-validation", "page-polish"), ("page-polish", "payment-validation"))]
+        self.assertTrue(any("cycle" in x for x in validate_situated_judgment(judgment, packet)))
+        for r in judgment["dependency_resolutions"]:
+            r["status"] = "satisfied"
+            r["evidence_refs"] = ["E-page" if r["prerequisite_id"] == "page-polish" else "E-payment"]
+        self.assertEqual(validate_situated_judgment(judgment, packet), [])
 
     def test_schema_vocabulary_and_json_type_boundaries(self):
         from sra_structure import validate_structure

--- a/tests/test_sra_v03_runtime_lifecycle.py
+++ b/tests/test_sra_v03_runtime_lifecycle.py
@@ -44,6 +44,29 @@ class SraV03RuntimeLifecycleTests(unittest.TestCase):
         prepare(input_path, run_dir)
         return run_dir
 
+    def test_dependency_block_and_valid_dual_view_replay(self):
+        data = input_data()
+        data["candidates"][1]["depends_on"] = ["page-polish"]
+        run_dir = self.prepare_run(data)
+        packet = load_json(run_dir / "situated-packet.json")
+        judgment = situated_judgment(packet)
+        judgment["dependency_resolutions"] = [{
+            "dependent_id": "payment-validation", "prerequisite_id": "page-polish",
+            "status": "unknown", "evidence_refs": [], "reason": "Missing prerequisite evidence.",
+        }]
+        before = {str(p.relative_to(run_dir)): p.read_bytes() for p in run_dir.rglob("*") if p.is_file()}
+        with self.assertRaises(SraRuntimeError):
+            record_situated(run_dir, judgment, carrier="packet_bound", receipt_path=None)
+        self.assertEqual(before, {str(p.relative_to(run_dir)): p.read_bytes() for p in run_dir.rglob("*") if p.is_file()})
+        judgment["dependency_resolutions"][0].update(status="satisfied", evidence_refs=["E-page"])
+        state = load_json(run_dir / "run.json")
+        challenge = challenge_from_situated(load_json(run_dir / "challenge-packet.json"), judgment, state["challenge_map"])
+        record_challenge(run_dir, challenge, carrier="packet_bound", receipt_path=None)
+        record_situated(run_dir, judgment, carrier="packet_bound", receipt_path=None)
+        self.assertEqual(run_check(run_dir)["status"], "ok")
+        self.assertEqual(load_json(run_dir / "run.json")["statuses"]["finalization"], "finalized")
+        self.assertTrue(repair_run(run_dir)["repaired"])
+
     def test_invalid_judgment_structure_leaves_run_byte_identical(self):
         data = input_data()
         data["contamination_signals"] = []


### PR DESCRIPTION
Closes #169; parent #167.

Packet dependencies now require bound satisfied/unmet/unknown resolutions. Current and immediate next commitments require satisfied prerequisites; already satisfied predecessors may receive no new resources. Bundle membership is not completion. Ready-frontier, conditional, alias, comparison, multi-hop and cycle checks are covered. No new waiver authority.

Baseline counterexample failed. Focused 131 pass. Full suite ran 1033: 1028 passed, 5 optional skips on Python 3.10.12. Lifecycle 76/76; all five package layouts include sra_dependencies.py. Invalid record is byte-preserving; valid two-view replay/check/repair succeeds. No release or tag.