### PR TITLE
test: consolidate redundant package builds without retiring protection

### DIFF
--- a/docs/internal/test-lifecycle-cleanup-wave-2-2026-09-05.md
+++ b/docs/internal/test-lifecycle-cleanup-wave-2-2026-09-05.md
@@ -1,0 +1,41 @@
+# Test Lifecycle Cleanup Wave 2 — 2026-09-05
+
+Parent #167, work item #170. This is the first low-risk slice, not a blanket retirement.
+Baseline before this slice: 749b9a33 (SRA dependency fix). No production files change.
+
+## Reviewed retirements
+
+| Retired executable owner | Protected invariant | Current replacement | Residual risk |
+|---|---|---|---|
+| V10ReadinessTests.test_release_pack_carries_license_judge_script_and_rubric | LICENSE, COMMERCIAL-LICENSE.md, fidelity judge and SELA rubric in three layouts | PackagingDocsTests.test_release_pack_builder_creates_claude_marketplace_root_layout calls _assert_packaged_fidelity_assets | None knowingly removed; all 12 original path assertions retained |
+| PackagingDocsTests.test_release_pack_includes_split_primitive_docs | Whole Elephant primitive document in five package roots | Same existing all-layout build validates all five exact paths | None knowingly removed; all five paths retained |
+
+The current package is now built once instead of three times for this assertion cluster.
+This does not share mutable packages across independent tests. Existing tests that modify
+packages or check separate package modes keep their own temporary output.
+
+## Replacement evidence
+
+`test_fidelity_asset_coverage_detects_each_missing_packaged_file` creates a temporary
+17-file tree. It removes each file separately, observes an AssertionError from the exact
+helper used by the real package test, then restores that file. This proves the replacement
+checks detect every retired assertion's missing-file failure. It does not certify file
+content or semantic judgment; other existing tests continue to cover those surfaces.
+
+Net test functions: minus one (two removed, one fault-injection table added).
+All original asset cases remain; test count reduction is not the acceptance criterion.
+
+## Preserved
+
+Historical v0.9/v1.0 acceptance reports, licensing text, judge exit legitimacy, privacy,
+authority, transaction, runtime recovery, prior SRA failure regressions and platform
+isolation tests remain executable. No historical test is retired solely due to age.
+
+## Evidence and remaining work
+
+Focused packaging/readiness/release tests: 64 run, 63 pass, one optional dependency skip.
+Whole-suite and remote CI results belong to this slice's PR and exact commit.
+The first slice removes two redundant builds; no percentage speed-up is claimed from a
+single noisy measurement. Remaining #170 work: review other assertion ownership overlaps
+and update test ownership after #171/#172 structural moves. Do not close the full issue
+based on this slice alone.

--- a/tests/test-lifecycle-registry.json
+++ b/tests/test-lifecycle-registry.json
@@ -113,7 +113,7 @@
       "lifecycle_status": "historical_guard",
       "suite_role": "acceptance",
       "runtime_cost": "medium",
-      "notes": "Wave 1 removed duplicate current-release assertions from the v0.9 and v1.0 readiness surfaces while preserving the unique historical acceptance and licensing contracts."
+      "notes": "Waves 1 and 2 preserve unique historical acceptance and licensing contracts. Current package asset checks formerly in v1.0 readiness now share the active packaging owner and a 17-path missing-asset fault-injection table; see test-lifecycle-cleanup-wave-2-2026-09-05.md."
     },
     {
       "test_id": "judgment-observability-and-case-export",

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -1286,6 +1286,39 @@ class PackagingDocsTests(unittest.TestCase):
             self.assertIn("repo-local _runtime", result.stdout)
             self.assertIn("copy _runtime plus runtime_bootstrap.py", result.stdout)
 
+    @staticmethod
+    def _static_release_asset_paths(root):
+        paths = []
+        for platform, skill_prefix in (("claude-code/claude-plugin", "skills"),
+                                       ("codex", "skills/mindthus"),
+                                       ("opencode", ".opencode/skills/mindthus")):
+            base = root / platform
+            paths.extend(base / name for name in ("LICENSE", "COMMERCIAL-LICENSE.md", "scripts/run-fidelity-judge.py"))
+            paths.append(base / skill_prefix / "sela/rubrics/judge.md")
+        for platform in ("claude-code", "claude-code/claude-plugin", "codex", "codex-plugin/mindthus", "opencode"):
+            paths.append(root / platform / "docs/methodologies/primitives/whole-elephant-protocol.md")
+        return paths
+
+    def _assert_packaged_fidelity_assets(self, root):
+        for path in self._static_release_asset_paths(root):
+            self.assertTrue(path.is_file(), str(path.relative_to(root)))
+
+    def test_fidelity_asset_coverage_detects_each_missing_packaged_file(self):
+        # Retirement evidence: every assertion moved from v1.0 still detects its loss.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = self._static_release_asset_paths(root)
+            for path in paths:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("fixture", encoding="utf-8")
+            self._assert_packaged_fidelity_assets(root)
+            for path in paths:
+                with self.subTest(asset=str(path.relative_to(root))):
+                    path.unlink()
+                    with self.assertRaises(AssertionError):
+                        self._assert_packaged_fidelity_assets(root)
+                    path.write_text("fixture", encoding="utf-8")
+
     def test_release_pack_builder_creates_claude_marketplace_root_layout(self):
         script = REPO / "scripts" / "build-release-pack.py"
         self.assertTrue(script.exists())
@@ -1312,6 +1345,7 @@ class PackagingDocsTests(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assert_release_pack_excludes_runtime_artifacts(out)
+            self._assert_packaged_fidelity_assets(out)
 
             for skill_dir in (
                 out / "claude-code" / "claude-plugin" / "skills" / "using-mindthus",
@@ -1564,28 +1598,6 @@ class PackagingDocsTests(unittest.TestCase):
                 )
                 for skill_name in skill_names:
                     self.assertNotIn(f"skills/{skill_name}/", markdown)
-
-    def test_release_pack_includes_split_primitive_docs(self):
-        script = REPO / "scripts" / "build-release-pack.py"
-        with tempfile.TemporaryDirectory() as tmp:
-            out = Path(tmp) / "release"
-            result = subprocess.run(
-                ["python3", str(script), "--out", str(out)],
-                text=True,
-                capture_output=True,
-            )
-            self.assertEqual(result.returncode, 0, result.stderr)
-
-            primitive_doc = Path("docs") / "methodologies" / "primitives" / "whole-elephant-protocol.md"
-            expected_roots = (
-                out / "claude-code",
-                out / "claude-code" / "claude-plugin",
-                out / "codex",
-                out / "codex-plugin" / "mindthus",
-                out / "opencode",
-            )
-            for root in expected_roots:
-                self.assertTrue((root / primitive_doc).exists(), f"{root} missing {primitive_doc}")
 
     def test_release_pack_builder_can_split_plugin_and_skills_packages(self):
         script = REPO / "scripts" / "build-release-pack.py"

--- a/tests/test_v1_0_readiness.py
+++ b/tests/test_v1_0_readiness.py
@@ -131,52 +131,6 @@ class V10ReadinessTests(unittest.TestCase):
         self.assertIn("SPDX `AGPL-3.0-only`", readme)
         self.assertIn("rather than encoded in the SPDX field", readme)
 
-    def test_release_pack_carries_license_judge_script_and_rubric(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            result = subprocess.run(
-                ["python3", "scripts/build-release-pack.py", "--out", tmp, "--force"],
-                text=True,
-                capture_output=True,
-                cwd=REPO,
-            )
-            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
-            root = Path(tmp)
-            for platform_root in (
-                root / "claude-code" / "claude-plugin",
-                root / "codex",
-                root / "opencode",
-            ):
-                self.assertTrue((platform_root / "LICENSE").is_file(), platform_root)
-                self.assertTrue((platform_root / "COMMERCIAL-LICENSE.md").is_file(), platform_root)
-                self.assertTrue((platform_root / "scripts" / "run-fidelity-judge.py").is_file(), platform_root)
-
-            self.assertTrue(
-                (
-                    root
-                    / "claude-code"
-                    / "claude-plugin"
-                    / "skills"
-                    / "sela"
-                    / "rubrics"
-                    / "judge.md"
-                ).is_file()
-            )
-            self.assertTrue(
-                (root / "codex" / "skills" / "mindthus" / "sela" / "rubrics" / "judge.md").is_file()
-            )
-            self.assertTrue(
-                (
-                    root
-                    / "opencode"
-                    / ".opencode"
-                    / "skills"
-                    / "mindthus"
-                    / "sela"
-                    / "rubrics"
-                    / "judge.md"
-                ).is_file()
-            )
-
     def test_sela_judge_rubric_reviews_method_exit_legitimacy(self):
         rubric = (REPO / "skills" / "sela" / "rubrics" / "judge.md").read_text(
             encoding="utf-8"


### PR DESCRIPTION
Part of #170, parent #167; does not close the full cleanup issue.

Moves 12 licensing/fidelity asset checks from historical readiness and five primitive-doc checks into the existing all-layout package build. Adds a 17-path temporary missing-file fault table to prove retained detection. Three builds become one in this cluster; no mutable cross-test fixture sharing. Historical/legal/runtime authority checks remain.

Full suite ran 1032: 1027 pass, 5 optional skips (Python 3.10.12). Focused 64 run/63 pass/1 skip; lifecycle 76/76; diff clean. No speed percentage claim from one timing. Retirement ledger: docs/internal/test-lifecycle-cleanup-wave-2-2026-09-05.md.