### PR TITLE
refactor(sra): isolate pure comparison without changing runtime decisions

### DIFF
--- a/docs/internal/maintenance-runtime-slices-20260905.md
+++ b/docs/internal/maintenance-runtime-slices-20260905.md
@@ -1,0 +1,30 @@
+# Runtime Maintenance Slices — 2026-09-05
+
+Parent #167. Each slice is a behavior-preserving move; semantic fixes are separate.
+
+## SRA slice 1 (#171)
+
+Baseline: 99c4cb23 (same SRA behavior as dependency fix 749b9a33).
+
+- `sra_views.py` owns candidate/bundle normalization and typed comparison.
+- `sra_serialization.py` owns canonical JSON and hashing used by both packets and views.
+- Existing public `sra_runtime` and `sra_runtime_core` names re-export the same function
+  objects. No copied implementation, wrapper decision, or reverse import to the facade.
+- `sra_structure.py` and `sra_dependencies.py` were already established by the two
+  separate defect fixes, not silently introduced as refactoring behavior.
+
+Review evidence: all seven moved function ASTs were compared with their definitions in
+`git show 99c4cb23:skills/sra/scripts/sra_runtime_core.py`; every AST is identical, ignoring
+location and comments. This is a one-time move proof, not a permanent test tied to old
+source layout. Existing agreement/conflict/hash/alias/repair tests remain the regression
+owner. The first focused rerun contains 131 passing tests.
+
+The core loses 198 definition lines and gains two explicit imports. This is not completion
+of every #171 checkbox: packet/input/schema generation/carrier and larger integrity
+organization remain separate follow-on slices. No same-wording conflict behavior was
+changed. Code size alone is not the acceptance criterion.
+
+## TPlan
+
+Not yet changed in this record. Pure extraction will precede any transaction/authority
+move; new implementation files must be added to the runtime manifest and fingerprints.

--- a/skills/sra/scripts/sra_runtime_core.py
+++ b/skills/sra/scripts/sra_runtime_core.py
@@ -13,6 +13,8 @@ from typing import Any, Iterable
 
 from sra_domain import *  # noqa: F403
 from sra_structure import validate_structure
+from sra_serialization import canonical_json, digest_data
+from sra_views import normalized_decision_core, compare_views
 from sra_dependencies import (
     dependency_edges, dependency_resolution_schema, validate_dependencies,
     normalized_dependency_resolutions,
@@ -63,14 +65,6 @@ class SraValidationError(SraRuntimeError):
 
 def now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
-
-
-def canonical_json(data: Any) -> str:
-    return json.dumps(data, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-
-
-def digest_data(data: Any) -> str:
-    return "sha256:" + hashlib.sha256(canonical_json(data).encode("utf-8")).hexdigest()
 
 
 def load_json(path: Path) -> Any:
@@ -2558,196 +2552,6 @@ def validate_reconciliation_judgment(
             "conflict_resolutions must cover every comparison conflict exactly once"
         )
     return findings
-
-
-def _mapped_candidate(value: Any, mapping: dict[str, str]) -> Any:
-    if value in {"reserve", "none", None}:
-        return value
-    return mapping.get(str(value), value)
-
-
-def _normalize_candidate_assessments(
-    judgment: dict[str, Any],
-    *,
-    id_field: str,
-    mapping: dict[str, str],
-) -> list[dict[str, Any]]:
-    values = []
-    for assessment in judgment.get("candidate_assessments", []):
-        if not isinstance(assessment, dict):
-            continue
-        values.append({
-            "candidate_id": _mapped_candidate(assessment.get(id_field), mapping),
-            "feasibility": assessment.get("feasibility"),
-            "candidate_role": assessment.get("candidate_role"),
-            "contraction_result": assessment.get("contraction_result"),
-        })
-    return sorted(values, key=lambda item: str(item["candidate_id"]))
-
-
-def _normalize_bundle_decision(
-    judgment: dict[str, Any],
-    *,
-    mapping: dict[str, str],
-) -> dict[str, Any]:
-    decision = judgment.get("bundle_decision", {})
-    if not isinstance(decision, dict):
-        return {"status": "invalid", "bundle_assessments": [], "selected_bundle": "invalid"}
-    local_to_key: dict[str, str] = {}
-    raw_assessments = decision.get("bundle_assessments", [])
-    if isinstance(raw_assessments, list):
-        for bundle in raw_assessments:
-            if not isinstance(bundle, dict):
-                continue
-            members = [
-                str(_mapped_candidate(member, mapping))
-                for member in bundle.get("member_ids", [])
-            ]
-            local_to_key[str(bundle.get("bundle_id"))] = canonical_bundle_key(members)  # noqa: F405
-    assessments = []
-    if isinstance(raw_assessments, list):
-        for bundle in raw_assessments:
-            if not isinstance(bundle, dict):
-                continue
-            members = sorted(
-                str(_mapped_candidate(member, mapping))
-                for member in bundle.get("member_ids", [])
-            )
-            assessments.append({
-                "bundle": canonical_bundle_key(members),  # noqa: F405
-                "member_ids": members,
-                "feasibility": bundle.get("feasibility"),
-                "dominance_status": bundle.get("dominance_status"),
-                "dominated_by": sorted(
-                    local_to_key.get(str(item), f"unknown:{item}")
-                    for item in bundle.get("dominated_by", [])
-                ),
-                "resource_requirements": normalize_resource_allocations(  # noqa: F405
-                    bundle.get("resource_requirements", [])
-                ),
-                "contraction_result": bundle.get("contraction_result"),
-            })
-    assessments.sort(key=lambda item: item["bundle"])
-    selected_id = str(decision.get("selected_bundle_id", "none"))
-    selected = "none" if selected_id == "none" else local_to_key.get(
-        selected_id, f"unknown:{selected_id}"
-    )
-    return {
-        "status": decision.get("status"),
-        "bundle_assessments": assessments,
-        "selected_bundle": selected,
-    }
-
-
-def normalized_decision_core(
-    judgment: dict[str, Any],
-    *,
-    id_field: str,
-    mapping: dict[str, str] | None = None,
-) -> dict[str, Any]:
-    mapping = mapping or {}
-    ledger: list[dict[str, Any]] = []
-    raw_ledger = judgment.get("allocation_ledger", [])
-    if isinstance(raw_ledger, list):
-        for entry in raw_ledger:
-            if not isinstance(entry, dict):
-                continue
-            ledger.append({
-                "candidate_id": _mapped_candidate(entry.get(id_field), mapping),
-                "posture": entry.get("posture"),
-                "current_allocations": normalize_resource_allocations(  # noqa: F405
-                    entry.get("current_allocations", [])
-                ),
-            })
-    ledger.sort(key=lambda item: str(item["candidate_id"]))
-    next_tranche = judgment.get("next_tranche", {})
-    if not isinstance(next_tranche, dict):
-        next_tranche = {}
-    reserve = judgment.get("reserve", {})
-    if not isinstance(reserve, dict):
-        reserve = {}
-    missing = judgment.get("missing_information", [])
-    return {
-        "allocation_outcome": judgment.get("allocation_outcome"),
-        "candidate_assessments": _normalize_candidate_assessments(
-            judgment, id_field=id_field, mapping=mapping
-        ),
-        "bundle_decision": _normalize_bundle_decision(judgment, mapping=mapping),
-        "allocation_ledger": ledger,
-        "next_tranche": {
-            "target_id": _mapped_candidate(
-                next_tranche.get("target_id", "none"), mapping
-            ),
-            "resource_allocations": normalize_resource_allocations(  # noqa: F405
-                next_tranche.get("resource_allocations", [])
-            ),
-            "window": next_tranche.get("window"),
-            "completion_signal": next_tranche.get("completion_signal"),
-            "start_condition": next_tranche.get("start_condition"),
-        },
-        "investment_ceiling": normalize_resource_allocations(  # noqa: F405
-            judgment.get("investment_ceiling", [])
-        ),
-        "authorization_horizon": judgment.get("authorization_horizon"),
-        "reserve": {
-            "status": reserve.get("status"),
-            "resource_allocations": normalize_resource_allocations(  # noqa: F405
-                reserve.get("resource_allocations", [])
-            ),
-            "release_trigger": reserve.get("release_trigger"),
-            "review_time": reserve.get("review_time"),
-        },
-        "missing_information": sorted(missing) if isinstance(missing, list) else [repr(missing)],
-        **({"dependency_resolutions": normalized_dependency_resolutions(judgment, mapping)}
-           if "dependency_resolutions" in judgment else {}),
-    }
-
-
-def compare_views(
-    *,
-    run_id: str,
-    challenge_packet_hash: str,
-    situated_packet_hash: str,
-    challenge_judgment: dict[str, Any],
-    situated_judgment: dict[str, Any],
-    challenge_map: dict[str, str],
-) -> dict[str, Any]:
-    challenge_core = normalized_decision_core(
-        challenge_judgment,
-        id_field="challenge_id",
-        mapping=challenge_map,
-    )
-    situated_core = normalized_decision_core(
-        situated_judgment,
-        id_field="candidate_id",
-    )
-    conflicts: list[dict[str, Any]] = []
-    for field in COMPARISON_FIELDS:  # noqa: F405
-        if challenge_core.get(field) != situated_core.get(field):
-            conflicts.append({
-                "field": field,
-                "challenge_value": challenge_core.get(field),
-                "situated_value": situated_core.get(field),
-            })
-    base = {
-        "schema_version": COMPARISON_SCHEMA,  # noqa: F405
-        "run_id": run_id,
-        "status": "agree" if not conflicts else "conflict",
-        "challenge_packet_hash": challenge_packet_hash,
-        "situated_packet_hash": situated_packet_hash,
-        "challenge_judgment_hash": digest_data(challenge_judgment),
-        "situated_judgment_hash": digest_data(situated_judgment),
-        "challenge_core_mapped": challenge_core,
-        "situated_core": situated_core,
-        "conflict_fields": conflicts,
-        "comparison_boundary": (
-            "Workflow compares typed commitments and codes only. Agreement is "
-            "corroboration, not proof; conflict chooses no winner."
-        ),
-    }
-    result = dict(base)
-    result["comparison_hash"] = digest_data(base)
-    return result
 
 
 def build_reconciliation_packet(

--- a/skills/sra/scripts/sra_serialization.py
+++ b/skills/sra/scripts/sra_serialization.py
@@ -1,0 +1,13 @@
+"""Canonical SRA serialization shared by packets, comparisons and runtime anchors."""
+from __future__ import annotations
+import hashlib
+import json
+from typing import Any
+
+
+def canonical_json(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def digest_data(data: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json(data).encode("utf-8")).hexdigest()

--- a/skills/sra/scripts/sra_views.py
+++ b/skills/sra/scripts/sra_views.py
@@ -1,0 +1,196 @@
+"""Pure SRA decision normalization and typed comparison; no runtime file access."""
+from __future__ import annotations
+from typing import Any
+from sra_domain import COMPARISON_FIELDS, COMPARISON_SCHEMA, canonical_bundle_key, normalize_resource_allocations
+from sra_dependencies import normalized_dependency_resolutions
+from sra_serialization import digest_data
+
+
+def _mapped_candidate(value: Any, mapping: dict[str, str]) -> Any:
+    if value in {"reserve", "none", None}:
+        return value
+    return mapping.get(str(value), value)
+
+
+def _normalize_candidate_assessments(
+    judgment: dict[str, Any],
+    *,
+    id_field: str,
+    mapping: dict[str, str],
+) -> list[dict[str, Any]]:
+    values = []
+    for assessment in judgment.get("candidate_assessments", []):
+        if not isinstance(assessment, dict):
+            continue
+        values.append({
+            "candidate_id": _mapped_candidate(assessment.get(id_field), mapping),
+            "feasibility": assessment.get("feasibility"),
+            "candidate_role": assessment.get("candidate_role"),
+            "contraction_result": assessment.get("contraction_result"),
+        })
+    return sorted(values, key=lambda item: str(item["candidate_id"]))
+
+
+def _normalize_bundle_decision(
+    judgment: dict[str, Any],
+    *,
+    mapping: dict[str, str],
+) -> dict[str, Any]:
+    decision = judgment.get("bundle_decision", {})
+    if not isinstance(decision, dict):
+        return {"status": "invalid", "bundle_assessments": [], "selected_bundle": "invalid"}
+    local_to_key: dict[str, str] = {}
+    raw_assessments = decision.get("bundle_assessments", [])
+    if isinstance(raw_assessments, list):
+        for bundle in raw_assessments:
+            if not isinstance(bundle, dict):
+                continue
+            members = [
+                str(_mapped_candidate(member, mapping))
+                for member in bundle.get("member_ids", [])
+            ]
+            local_to_key[str(bundle.get("bundle_id"))] = canonical_bundle_key(members)
+    assessments = []
+    if isinstance(raw_assessments, list):
+        for bundle in raw_assessments:
+            if not isinstance(bundle, dict):
+                continue
+            members = sorted(
+                str(_mapped_candidate(member, mapping))
+                for member in bundle.get("member_ids", [])
+            )
+            assessments.append({
+                "bundle": canonical_bundle_key(members),
+                "member_ids": members,
+                "feasibility": bundle.get("feasibility"),
+                "dominance_status": bundle.get("dominance_status"),
+                "dominated_by": sorted(
+                    local_to_key.get(str(item), f"unknown:{item}")
+                    for item in bundle.get("dominated_by", [])
+                ),
+                "resource_requirements": normalize_resource_allocations(
+                    bundle.get("resource_requirements", [])
+                ),
+                "contraction_result": bundle.get("contraction_result"),
+            })
+    assessments.sort(key=lambda item: item["bundle"])
+    selected_id = str(decision.get("selected_bundle_id", "none"))
+    selected = "none" if selected_id == "none" else local_to_key.get(
+        selected_id, f"unknown:{selected_id}"
+    )
+    return {
+        "status": decision.get("status"),
+        "bundle_assessments": assessments,
+        "selected_bundle": selected,
+    }
+
+
+def normalized_decision_core(
+    judgment: dict[str, Any],
+    *,
+    id_field: str,
+    mapping: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    mapping = mapping or {}
+    ledger: list[dict[str, Any]] = []
+    raw_ledger = judgment.get("allocation_ledger", [])
+    if isinstance(raw_ledger, list):
+        for entry in raw_ledger:
+            if not isinstance(entry, dict):
+                continue
+            ledger.append({
+                "candidate_id": _mapped_candidate(entry.get(id_field), mapping),
+                "posture": entry.get("posture"),
+                "current_allocations": normalize_resource_allocations(
+                    entry.get("current_allocations", [])
+                ),
+            })
+    ledger.sort(key=lambda item: str(item["candidate_id"]))
+    next_tranche = judgment.get("next_tranche", {})
+    if not isinstance(next_tranche, dict):
+        next_tranche = {}
+    reserve = judgment.get("reserve", {})
+    if not isinstance(reserve, dict):
+        reserve = {}
+    missing = judgment.get("missing_information", [])
+    return {
+        "allocation_outcome": judgment.get("allocation_outcome"),
+        "candidate_assessments": _normalize_candidate_assessments(
+            judgment, id_field=id_field, mapping=mapping
+        ),
+        "bundle_decision": _normalize_bundle_decision(judgment, mapping=mapping),
+        "allocation_ledger": ledger,
+        "next_tranche": {
+            "target_id": _mapped_candidate(
+                next_tranche.get("target_id", "none"), mapping
+            ),
+            "resource_allocations": normalize_resource_allocations(
+                next_tranche.get("resource_allocations", [])
+            ),
+            "window": next_tranche.get("window"),
+            "completion_signal": next_tranche.get("completion_signal"),
+            "start_condition": next_tranche.get("start_condition"),
+        },
+        "investment_ceiling": normalize_resource_allocations(
+            judgment.get("investment_ceiling", [])
+        ),
+        "authorization_horizon": judgment.get("authorization_horizon"),
+        "reserve": {
+            "status": reserve.get("status"),
+            "resource_allocations": normalize_resource_allocations(
+                reserve.get("resource_allocations", [])
+            ),
+            "release_trigger": reserve.get("release_trigger"),
+            "review_time": reserve.get("review_time"),
+        },
+        "missing_information": sorted(missing) if isinstance(missing, list) else [repr(missing)],
+        **({"dependency_resolutions": normalized_dependency_resolutions(judgment, mapping)}
+           if "dependency_resolutions" in judgment else {}),
+    }
+
+
+def compare_views(
+    *,
+    run_id: str,
+    challenge_packet_hash: str,
+    situated_packet_hash: str,
+    challenge_judgment: dict[str, Any],
+    situated_judgment: dict[str, Any],
+    challenge_map: dict[str, str],
+) -> dict[str, Any]:
+    challenge_core = normalized_decision_core(
+        challenge_judgment,
+        id_field="challenge_id",
+        mapping=challenge_map,
+    )
+    situated_core = normalized_decision_core(
+        situated_judgment,
+        id_field="candidate_id",
+    )
+    conflicts: list[dict[str, Any]] = []
+    for field in COMPARISON_FIELDS:
+        if challenge_core.get(field) != situated_core.get(field):
+            conflicts.append({
+                "field": field,
+                "challenge_value": challenge_core.get(field),
+                "situated_value": situated_core.get(field),
+            })
+    base = {
+        "schema_version": COMPARISON_SCHEMA,
+        "run_id": run_id,
+        "status": "agree" if not conflicts else "conflict",
+        "challenge_packet_hash": challenge_packet_hash,
+        "situated_packet_hash": situated_packet_hash,
+        "challenge_judgment_hash": digest_data(challenge_judgment),
+        "situated_judgment_hash": digest_data(situated_judgment),
+        "challenge_core_mapped": challenge_core,
+        "situated_core": situated_core,
+        "conflict_fields": conflicts,
+        "comparison_boundary": (
+            "Workflow compares typed commitments and codes only. Agreement is "
+            "corroboration, not proof; conflict chooses no winner."
+        ),
+    }
+    result = dict(base)
+    result["comparison_hash"] = digest_data(base)
+    return result


### PR DESCRIPTION
Part of #171, parent #167. Slice 1 only; input/schema/carrier and integrity decomposition remain open.

Seven moved function ASTs match the prior definitions exactly. New modules explicitly depend on domain/dependency/serialization, never the facade. Existing public imports are direct function aliases.

Focused 131 pass; full suite ran 1032 (1027 passed, 5 optional skips), lifecycle76/76, all-layout build including sra_views.py and sra_serialization.py, diff clean. No behavior fix hidden in this move, no release.