### PR TITLE
test: finalize lifecycle ownership cleanup

### DIFF
--- a/docs/internal/test-lifecycle-cleanup-wave-3-2026-09-05.md
+++ b/docs/internal/test-lifecycle-cleanup-wave-3-2026-09-05.md
@@ -1,0 +1,42 @@
+# Test Lifecycle Cleanup Wave 3 — 2026-09-05
+
+Parent #167, work item #170. This slice completes the planned ownership cleanup after
+#171/#172 split work landed on main. It moves current contracts out of the historical
+v1.0 readiness owner; it does not retire the historical evidence itself.
+
+## Ownership moves
+
+| Previous owner | Contract moved to | Why |
+|---|---|---|
+| `V10ReadinessTests.test_codex_install_doc_no_longer_calls_public_repo_private` | `PackagingDocsTests.test_codex_install_doc_names_tplan` | Codex install documentation is a current packaging/install surface, not v1.0 history. |
+| `V10ReadinessTests.test_agpl_dual_license_surface_is_declared` | `ReleaseBoundaryContractTests.test_dual_license_public_boundary_is_declared` | Licensing is a current release/public boundary and must not depend on a historical readiness suite. |
+| v1.0 SELA judge rubric/exit tests plus local judge fixture helpers | `SelaFidelityTests` | Judge behavior is the current SELA fidelity owner. The same complete, blocked-exit, and reviewed-exit behaviors remain executable. |
+
+`tests/test_v1_0_readiness.py` now protects only two historical artifacts: the dated v1.0
+readiness closure record and the dated cross-model baseline scope. Its lifecycle remains
+`historical_guard`.
+
+## What was deliberately not consolidated
+
+- Whole Elephant/router/primitive tests share vocabulary but protect different layers:
+  documentation/routing contracts, deterministic primitive activation, and direct
+  Whole-Elephant validation. Shared strings are not retirement evidence.
+- SRA contract/domain/runtime-lifecycle tests overlap field names but protect different
+  failure classes and are kept after the v0.3 contract repairs.
+- TPlan authority, transaction, recovery, privacy, telemetry and provenance tests remain
+  active gates and were not trimmed during module extraction.
+
+## Exit decision for #170
+
+The cleanup goal is ownership clarity and lower duplicate maintenance, not an arbitrary
+file/test-count target. Waves 1–3 have now:
+
+1. removed duplicate current-release assertions from historical readiness owners;
+2. collapsed redundant release-package builds while preserving exact path checks with
+   fault-injection coverage;
+3. returned install, licensing, and SELA judge contracts to their current owners;
+4. preserved historical records and high-risk runtime regressions.
+
+No further retirement is justified by evidence gathered in this maintenance campaign.
+Future cleanup requires a new replacement-coverage review rather than continuing because
+some test files are large.

--- a/tests/test-lifecycle-registry.json
+++ b/tests/test-lifecycle-registry.json
@@ -114,7 +114,7 @@
       "lifecycle_status": "historical_guard",
       "suite_role": "acceptance",
       "runtime_cost": "medium",
-      "notes": "Waves 1 and 2 preserve unique historical acceptance and licensing contracts. Current package asset checks formerly in v1.0 readiness now share the active packaging owner and a 17-path missing-asset fault-injection table; see test-lifecycle-cleanup-wave-2-2026-09-05.md."
+      "notes": "Waves 1-3 preserve unique historical acceptance records while current install, licensing, package-asset, and SELA judge contracts live under their active owners. See test-lifecycle-cleanup-wave-2-2026-09-05.md and test-lifecycle-cleanup-wave-3-2026-09-05.md."
     },
     {
       "test_id": "judgment-observability-and-case-export",

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -1108,6 +1108,7 @@ class PackagingDocsTests(unittest.TestCase):
         script = (REPO / "scripts" / "install-skills.sh").read_text(encoding="utf-8")
         self.assertIn("mindthus:tplan", install)
         self.assertIn("scripts/install-skills.sh", install)
+        self.assertNotIn("private `rv198-star/Mindthus` repository", install)
         for text in (install, readme, script):
             self.assertIn("CODEX_HOME", text)
             self.assertIn("skills/mindthus", text)

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -7,6 +7,34 @@ REPO = Path(__file__).resolve().parents[1]
 
 
 class ReleaseBoundaryContractTests(unittest.TestCase):
+    def test_dual_license_public_boundary_is_declared(self):
+        license_text = (REPO / "LICENSE").read_text(encoding="utf-8")
+        commercial_text = (REPO / "COMMERCIAL-LICENSE.md").read_text(encoding="utf-8")
+        readme = (REPO / "README.md").read_text(encoding="utf-8")
+        for phrase in (
+            "GNU AFFERO GENERAL PUBLIC LICENSE",
+            "Version 3, 19 November 2007",
+            "TERMS AND CONDITIONS",
+            "END OF TERMS AND CONDITIONS",
+        ):
+            self.assertIn(phrase, license_text)
+        for phrase in (
+            "AGPLv3",
+            "commercial dual licensing",
+            "closed-source commercial",
+            "private SaaS",
+            "commercial integration",
+            "separate commercial license",
+            "not legal advice",
+        ):
+            self.assertIn(phrase, commercial_text)
+        self.assertIn("https://github.com/rv198-star/Mindthus/issues", commercial_text)
+        self.assertIn("prompt-level", commercial_text)
+        self.assertIn("AGPLv3 + commercial dual licensing", readme)
+        self.assertIn("closed-source commercial use requires a separate commercial license", readme)
+        self.assertIn("SPDX `AGPL-3.0-only`", readme)
+        self.assertIn("rather than encoded in the SPDX field", readme)
+
     def test_current_release_log_does_not_record_exact_suite_count(self):
         release_log = (REPO / "docs" / "releases" / "v1.9.1.md").read_text(
             encoding="utf-8"

--- a/tests/test_sela_fidelity.py
+++ b/tests/test_sela_fidelity.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 VALIDATOR = REPO / "skills" / "sela" / "scripts" / "validate_sela_output.py"
+JUDGE_RUNNER = REPO / "scripts" / "run-fidelity-judge.py"
 
 
 def valid_output() -> dict:
@@ -39,6 +40,43 @@ def run_validator(payload: dict) -> subprocess.CompletedProcess[str]:
         path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
         return subprocess.run(
             ["python3", str(VALIDATOR), str(path)],
+            text=True,
+            capture_output=True,
+            cwd=REPO,
+        )
+
+
+def complete_judge() -> dict:
+    dimensions = {
+        f"D{index}": {
+            "score": 2,
+            "rationale": f"D{index} was judged against the rubric with concrete evidence.",
+            "evidence": f"D{index} evidence excerpt.",
+        }
+        for index in range(1, 7)
+    }
+    return {
+        "schema_version": "mindthus-fidelity-judge-v0.1",
+        "method": "SELA",
+        "judge_model": "fixture-judge",
+        "rubric": "skills/sela/rubrics/judge.md",
+        "dimensions": dimensions,
+        "final_assessment": {
+            "total_score": 12,
+            "summary": "The artifact faithfully executed the SELA moves.",
+            "form_compliance_not_enough": True,
+        },
+    }
+
+
+def run_judge(output_payload: dict, judge_payload: dict) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as tmp:
+        output_path = Path(tmp) / "sela-output.json"
+        judge_path = Path(tmp) / "judge.json"
+        output_path.write_text(json.dumps(output_payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        judge_path.write_text(json.dumps(judge_payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        return subprocess.run(
+            ["python3", str(JUDGE_RUNNER), "--output", str(output_path), "--judge", str(judge_path)],
             text=True,
             capture_output=True,
             cwd=REPO,
@@ -109,6 +147,61 @@ class SelaFidelityTests(unittest.TestCase):
             "scripts must not decide semantic truth",
         ):
             self.assertIn(phrase, text)
+
+    def test_sela_judge_rubric_reviews_method_exit_legitimacy(self):
+        rubric = (REPO / "skills" / "sela" / "rubrics" / "judge.md").read_text(
+            encoding="utf-8"
+        )
+        for phrase in (
+            "escape review",
+            "not_applicable",
+            "transfer",
+            "challenge_premise",
+            "the judge must review whether the exit itself is justified",
+            "do not automatically pass a method exit",
+        ):
+            self.assertIn(phrase, rubric)
+
+    def test_fidelity_judge_runner_accepts_complete_sela_judgment(self):
+        result = run_judge(valid_output(), complete_judge())
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("Fidelity Judge Report", result.stdout)
+        self.assertIn("Total score: 12 / 12", result.stdout)
+        self.assertIn("judge automation does not validate strategic truth", result.stdout)
+
+    def test_fidelity_judge_runner_blocks_unreviewed_method_exit(self):
+        payload = {
+            "schema_version": "sela-fidelity-v0.1",
+            "method": "SELA",
+            "applicability": "challenge_premise",
+            "plain_language_conclusion": "The prompt tries to use SELA to skip safety authority.",
+            "exit_reason": "Medical triage authority cannot be reduced to system efficiency.",
+            "transfer_to": "WAE",
+        }
+        result = run_judge(payload, complete_judge())
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("escape_review is required", result.stdout)
+        self.assertIn("challenge_premise", result.stdout)
+
+    def test_fidelity_judge_runner_accepts_reviewed_method_exit(self):
+        payload = {
+            "schema_version": "sela-fidelity-v0.1",
+            "method": "SELA",
+            "applicability": "challenge_premise",
+            "plain_language_conclusion": "The prompt tries to use SELA to skip safety authority.",
+            "exit_reason": "Medical triage authority cannot be reduced to system efficiency.",
+            "transfer_to": "WAE",
+        }
+        judge = complete_judge()
+        judge["escape_review"] = {
+            "applicability_exit": "challenge_premise",
+            "is_exit_justified": True,
+            "rationale": "The prompt asks SELA to override clinical safety authority.",
+            "reviewer_action": "accept_exit",
+        }
+        result = run_judge(payload, judge)
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("escape review accepted: challenge_premise", result.stdout)
 
     def test_sela_judge_rubric_and_evaluation_packet_exist(self):
         rubric = (REPO / "skills" / "sela" / "rubrics" / "judge.md").read_text(

--- a/tests/test_v1_0_readiness.py
+++ b/tests/test_v1_0_readiness.py
@@ -1,95 +1,15 @@
-import json
-import subprocess
-import tempfile
 import unittest
 from pathlib import Path
 
 
 REPO = Path(__file__).resolve().parents[1]
-JUDGE_RUNNER = REPO / "scripts" / "run-fidelity-judge.py"
-
-
-def sela_applicable_output() -> dict:
-    move = {
-        "status": "addressed",
-        "finding": "The output executes this SELA move with case-specific reasoning.",
-        "failure_criteria_response": "The output names how this move could fail.",
-        "evidence_surface": "Scenario facts and stated uncertainty.",
-    }
-    return {
-        "schema_version": "sela-fidelity-v0.1",
-        "method": "SELA",
-        "applicability": "applicable",
-        "plain_language_conclusion": "Use SELA for direction and stage the action.",
-        "action_posture": "stage",
-        "required_judgment_moves": {
-            "fair_comparison_check": dict(move),
-            "local_advantage_scalability": dict(move),
-            "system_efficiency_trajectory": dict(move),
-            "hard_boundary_check": dict(move),
-            "timing_action_posture": dict(move),
-            "misuse_challenge": dict(move),
-        },
-    }
-
-
-def sela_exit_output() -> dict:
-    return {
-        "schema_version": "sela-fidelity-v0.1",
-        "method": "SELA",
-        "applicability": "challenge_premise",
-        "plain_language_conclusion": "The prompt tries to use SELA to skip safety authority.",
-        "exit_reason": "Medical triage authority cannot be reduced to system efficiency.",
-        "transfer_to": "WAE",
-    }
-
-
-def complete_sela_judge() -> dict:
-    dimensions = {}
-    for index in range(1, 7):
-        dimensions[f"D{index}"] = {
-            "score": 2,
-            "rationale": f"D{index} was judged against the rubric with concrete evidence.",
-            "evidence": f"D{index} evidence excerpt.",
-        }
-    return {
-        "schema_version": "mindthus-fidelity-judge-v0.1",
-        "method": "SELA",
-        "judge_model": "fixture-judge",
-        "rubric": "skills/sela/rubrics/judge.md",
-        "dimensions": dimensions,
-        "final_assessment": {
-            "total_score": 12,
-            "summary": "The artifact faithfully executed the SELA moves.",
-            "form_compliance_not_enough": True,
-        },
-    }
-
-
-def run_judge(output_payload: dict, judge_payload: dict) -> subprocess.CompletedProcess[str]:
-    with tempfile.TemporaryDirectory() as tmp:
-        output_path = Path(tmp) / "sela-output.json"
-        judge_path = Path(tmp) / "judge.json"
-        output_path.write_text(json.dumps(output_payload, ensure_ascii=False, indent=2), encoding="utf-8")
-        judge_path.write_text(json.dumps(judge_payload, ensure_ascii=False, indent=2), encoding="utf-8")
-        return subprocess.run(
-            ["python3", str(JUDGE_RUNNER), "--output", str(output_path), "--judge", str(judge_path)],
-            text=True,
-            capture_output=True,
-            cwd=REPO,
-        )
 
 
 class V10ReadinessTests(unittest.TestCase):
-    def test_codex_install_doc_no_longer_calls_public_repo_private(self):
-        install = (REPO / ".codex" / "INSTALL.md").read_text(encoding="utf-8")
-        self.assertNotIn("private `rv198-star/Mindthus` repository", install)
-
     def test_v1_0_readiness_record_has_minimum_contract(self):
         text = (REPO / "tests" / "method_fidelity_v1_0_readiness_2026-06-08.md").read_text(
             encoding="utf-8"
         )
-
         for phrase in (
             "# v1.0 Readiness Blocker Closure",
             "## Closed Items",
@@ -100,86 +20,10 @@ class V10ReadinessTests(unittest.TestCase):
         ):
             self.assertIn(phrase, text)
 
-    def test_agpl_dual_license_surface_is_declared(self):
-        license_text = (REPO / "LICENSE").read_text(encoding="utf-8")
-        commercial_text = (REPO / "COMMERCIAL-LICENSE.md").read_text(encoding="utf-8")
-        readme = (REPO / "README.md").read_text(encoding="utf-8")
-
-        for phrase in (
-            "GNU AFFERO GENERAL PUBLIC LICENSE",
-            "Version 3, 19 November 2007",
-            "TERMS AND CONDITIONS",
-            "END OF TERMS AND CONDITIONS",
-        ):
-            self.assertIn(phrase, license_text)
-
-        for phrase in (
-            "AGPLv3",
-            "commercial dual licensing",
-            "closed-source commercial",
-            "private SaaS",
-            "commercial integration",
-            "separate commercial license",
-        ):
-            self.assertIn(phrase, commercial_text)
-        self.assertIn("https://github.com/rv198-star/Mindthus/issues", commercial_text)
-        self.assertIn("prompt-level", commercial_text)
-        self.assertIn("not legal advice", commercial_text)
-
-        self.assertIn("AGPLv3 + commercial dual licensing", readme)
-        self.assertIn("closed-source commercial use requires a separate commercial license", readme)
-        self.assertIn("SPDX `AGPL-3.0-only`", readme)
-        self.assertIn("rather than encoded in the SPDX field", readme)
-
-    def test_sela_judge_rubric_reviews_method_exit_legitimacy(self):
-        rubric = (REPO / "skills" / "sela" / "rubrics" / "judge.md").read_text(
-            encoding="utf-8"
-        )
-
-        for phrase in (
-            "escape review",
-            "not_applicable",
-            "transfer",
-            "challenge_premise",
-            "the judge must review whether the exit itself is justified",
-            "do not automatically pass a method exit",
-        ):
-            self.assertIn(phrase, rubric)
-
-    def test_fidelity_judge_runner_accepts_complete_sela_judgment(self):
-        result = run_judge(sela_applicable_output(), complete_sela_judge())
-
-        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
-        self.assertIn("Fidelity Judge Report", result.stdout)
-        self.assertIn("Total score: 12 / 12", result.stdout)
-        self.assertIn("judge automation does not validate strategic truth", result.stdout)
-
-    def test_fidelity_judge_runner_blocks_unreviewed_method_exit(self):
-        result = run_judge(sela_exit_output(), complete_sela_judge())
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("escape_review is required", result.stdout)
-        self.assertIn("challenge_premise", result.stdout)
-
-    def test_fidelity_judge_runner_accepts_reviewed_method_exit(self):
-        judge_payload = complete_sela_judge()
-        judge_payload["escape_review"] = {
-            "applicability_exit": "challenge_premise",
-            "is_exit_justified": True,
-            "rationale": "The prompt asks SELA to override clinical safety authority.",
-            "reviewer_action": "accept_exit",
-        }
-
-        result = run_judge(sela_exit_output(), judge_payload)
-
-        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
-        self.assertIn("escape review accepted: challenge_premise", result.stdout)
-
     def test_cross_model_baseline_records_second_model_scope(self):
         text = (REPO / "tests" / "sela" / "cross_model_baseline_2026-06-08.md").read_text(
             encoding="utf-8"
         )
-
         for phrase in (
             "SELA Cross-Model Baseline",
             "model_count: 2",


### PR DESCRIPTION
Closes #170. Moves current install, licensing, and SELA judge contracts out of historical v1.0 readiness ownership; keeps only historical evidence there. Focused 70 tests pass (1 optional skip); full suite 1036 run, 5 skips; lifecycle 77/77 valid.