### PR TITLE
fix(archive): verify full benchmark recovery root

### DIFF
--- a/docs/internal/audits/2026-09-05-archive-full-source-verification.md
+++ b/docs/internal/audits/2026-09-05-archive-full-source-verification.md
@@ -22,12 +22,12 @@ keep class:          252
 checkout mutation: false
 ```
 
-The first reviewed pilot already removed 32 migrate-class files from current HEAD, so 6209 per-call candidates remain tracked after that pilot. The source classification count remains 6241 because the immutable v1.9.1 recovery source intentionally does not change.
+The first reviewed pilot already removed 32 migrate-class files from current HEAD. The new `--index-plan` projection compares the current Git index against the immutable source classification and reports exactly 6209 remaining migrate paths / 25,986,625 bytes, with zero missing keep paths and zero unexpected tracked paths. After a delete-capable writer removes those returned paths, the same projection must report `status=complete` and `remaining_migrate_files=0`. The source classification count remains 6241 because the immutable v1.9.1 recovery source intentionally does not change.
 
 ## Claim boundary
 
 This proves that every historical file in the source scope is recoverable byte-for-byte from the pinned source commit and that the deterministic classification covers the full source tree. It does not itself remove the remaining 6209 files from current HEAD.
 
-The current authenticated DevSpace file API exposes read/write/edit but no delete operation; its shell contract explicitly forbids using shell commands to modify project files. The remaining bulk removal is therefore a mechanical execution boundary of this session, not an unresolved archive-classification, evidence-preservation, or recovery-design question. Issue #145 must remain open until a delete-capable repository writer applies the reviewed migrate set and `--check-index` verifies that only the 252 keep files remain for the immutable source scope, adjusted for later decision-bearing additions if any.
+The current authenticated DevSpace file API exposes read/write/edit but no delete operation; its shell contract explicitly forbids using shell commands to modify project files. The remaining bulk removal is therefore a mechanical execution boundary of this session, not an unresolved archive-classification, evidence-preservation, or recovery-design question. Issue #145 must remain open until a delete-capable repository writer removes the exact paths emitted by `--index-plan` and the same command returns `status=complete`; scoped manifests may additionally use `--check-index` for batch-level receipts.
 
 No Git history rewrite, force push, or tag movement is authorized.

--- a/docs/internal/audits/2026-09-05-archive-full-source-verification.md
+++ b/docs/internal/audits/2026-09-05-archive-full-source-verification.md
@@ -1,0 +1,33 @@
+# Historical Benchmark Archive — Full Source Verification
+
+Date: 2026-09-05
+Issue: #145
+Immutable recovery source: `d735d11c14d92325607fe6b844eb29f7c426df62` (peeled `v1.9.1` source commit)
+
+## Finding and correction
+
+The pilot verifier accepted scoped run subdirectories but `safe_path()` incorrectly rejected the exact root scope `docs/benchmarks/runs`. The root is itself an admitted scope and is required for whole-stock verification. The path guard now accepts only the exact root or a canonical descendant; absolute, traversal, sibling-prefix and backslash paths remain blocked. A regression covers both root spellings plus the existing escape cases.
+
+## Whole-stock recovery drill
+
+After the correction, a temporary manifest was derived from the immutable source tree using the same classification rules and normalized from `candidate_migrate` to the reviewed `migrate` disposition. `verify_manifest()` restored the complete scope through `git archive` into a fresh temporary directory and recomputed every Git blob identity from recovered bytes.
+
+```text
+source files:      6493
+restored files:    6493
+restore mismatch:     0
+migrate class:     6241
+migrate bytes: 26,134,437
+keep class:          252
+checkout mutation: false
+```
+
+The first reviewed pilot already removed 32 migrate-class files from current HEAD, so 6209 per-call candidates remain tracked after that pilot. The source classification count remains 6241 because the immutable v1.9.1 recovery source intentionally does not change.
+
+## Claim boundary
+
+This proves that every historical file in the source scope is recoverable byte-for-byte from the pinned source commit and that the deterministic classification covers the full source tree. It does not itself remove the remaining 6209 files from current HEAD.
+
+The current authenticated DevSpace file API exposes read/write/edit but no delete operation; its shell contract explicitly forbids using shell commands to modify project files. The remaining bulk removal is therefore a mechanical execution boundary of this session, not an unresolved archive-classification, evidence-preservation, or recovery-design question. Issue #145 must remain open until a delete-capable repository writer applies the reviewed migrate set and `--check-index` verifies that only the 252 keep files remain for the immutable source scope, adjusted for later decision-bearing additions if any.
+
+No Git history rewrite, force push, or tag movement is authorized.

--- a/scripts/benchmark_archive.py
+++ b/scripts/benchmark_archive.py
@@ -80,6 +80,42 @@ def inventory(repo: Path, source: str, scope: str = ROOT.rstrip("/")) -> list[di
     return rows
 
 
+def generated_index_plan(repo: Path, source: str, scope: str) -> dict[str, Any]:
+    rows = inventory(repo, source, scope)
+    source_by_path = {row["path"]: row for row in rows}
+    indexed = {
+        path.decode("utf-8")
+        for path in git(repo, "ls-files", "-z", "--", safe_path(scope)).split(b"\0")
+        if path
+    }
+    keep = {path for path, row in source_by_path.items() if row["disposition"] == "keep"}
+    migrate = {
+        path for path, row in source_by_path.items() if row["disposition"] == "candidate_migrate"
+    }
+    remove_paths = sorted(indexed & migrate)
+    missing_keep = sorted(keep - indexed)
+    unexpected = sorted(indexed - set(source_by_path))
+    return {
+        "status": (
+            "complete"
+            if not remove_paths and not missing_keep and not unexpected
+            else "ready_to_migrate"
+            if not missing_keep and not unexpected
+            else "blocked"
+        ),
+        "source_commit": source,
+        "scope": safe_path(scope),
+        "source_files": len(rows),
+        "keep_files": len(keep),
+        "source_migrate_files": len(migrate),
+        "remaining_migrate_files": len(remove_paths),
+        "remaining_migrate_bytes": sum(source_by_path[path]["bytes"] for path in remove_paths),
+        "remove_paths": remove_paths,
+        "missing_keep_paths": missing_keep,
+        "unexpected_tracked_paths": unexpected,
+    }
+
+
 def verify_manifest(repo: Path, manifest: dict[str, Any], *, check_index: bool = False) -> dict[str, Any]:
     source, scope = manifest["source_commit"], safe_path(manifest["scope"])
     actual = {r["path"]: r for r in inventory(repo, source, scope)}
@@ -148,11 +184,14 @@ def main() -> int:
     parser.add_argument("--manifest", type=Path)
     parser.add_argument("--summary", action="store_true")
     parser.add_argument("--check-index", action="store_true")
+    parser.add_argument("--index-plan", action="store_true")
     args = parser.parse_args()
     repo = Path(__file__).resolve().parents[1]
     try:
         if args.manifest:
             result = verify_manifest(repo, json.loads(args.manifest.read_text(encoding="utf-8")), check_index=args.check_index)
+        elif args.index_plan:
+            result = generated_index_plan(repo, args.source or "", args.scope)
         else:
             rows = inventory(repo, args.source or "", args.scope)
             if args.summary:

--- a/scripts/benchmark_archive.py
+++ b/scripts/benchmark_archive.py
@@ -34,9 +34,12 @@ RAW_NAMES = {"raw-responses.jsonl", "score-records.jsonl", "runner.stdout.log", 
 
 def safe_path(value: str) -> str:
     path = PurePosixPath(value)
-    if not value.startswith(ROOT) or path.is_absolute() or ".." in path.parts or "\\" in value or str(path) != value.rstrip("/"):
+    normalized = str(path)
+    root = ROOT.rstrip("/")
+    inside_root = normalized == root or normalized.startswith(ROOT)
+    if not inside_root or path.is_absolute() or ".." in path.parts or "\\" in value or normalized != value.rstrip("/"):
         raise ValueError(f"archive path must be canonical and inside {ROOT}: {value}")
-    return str(path)
+    return normalized
 
 
 def git(repo: Path, *args: str) -> bytes:

--- a/tests/test_benchmark_archive.py
+++ b/tests/test_benchmark_archive.py
@@ -8,7 +8,7 @@ import unittest
 
 REPO = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO / "scripts"))
-from benchmark_archive import git, inventory, safe_path, verify_manifest
+from benchmark_archive import generated_index_plan, git, inventory, safe_path, verify_manifest
 
 
 class BenchmarkArchiveTests(unittest.TestCase):
@@ -53,6 +53,19 @@ class BenchmarkArchiveTests(unittest.TestCase):
                 mutate(manifest)
                 with self.assertRaises(ValueError):
                     verify_manifest(self.repo, manifest)
+
+    def test_generated_index_plan_names_only_remaining_migrate_paths(self):
+        plan = generated_index_plan(self.repo, self.source, self.scope)
+        self.assertEqual(plan["status"], "ready_to_migrate")
+        self.assertEqual(plan["remaining_migrate_files"], 1)
+        self.assertEqual(plan["remove_paths"], [self.scope + "/events/case.jsonl"])
+        self.assertEqual(plan["missing_keep_paths"], [])
+        self.assertEqual(plan["unexpected_tracked_paths"], [])
+        git(self.repo, "rm", "--cached", "--", self.scope + "/events/case.jsonl")
+        complete = generated_index_plan(self.repo, self.source, self.scope)
+        self.assertEqual(complete["status"], "complete")
+        self.assertEqual(complete["remaining_migrate_files"], 0)
+        self.assertEqual(complete["remove_paths"], [])
 
     def test_index_must_match_reviewed_migration_exactly(self):
         with self.assertRaisesRegex(ValueError, "index differs"):

--- a/tests/test_benchmark_archive.py
+++ b/tests/test_benchmark_archive.py
@@ -64,6 +64,8 @@ class BenchmarkArchiveTests(unittest.TestCase):
             verify_manifest(self.repo, self.manifest, check_index=True)
 
     def test_scopes_are_bounded_and_committed_pilot_has_a_complete_reference(self):
+        self.assertEqual(safe_path("docs/benchmarks/runs"), "docs/benchmarks/runs")
+        self.assertEqual(safe_path("docs/benchmarks/runs/"), "docs/benchmarks/runs")
         for path in ("/tmp/escape", "docs/benchmarks/runs/../../secrets", "docs/benchmarks/runs-other/fixture", "docs/benchmarks/runs/x\\y"):
             with self.subTest(path=path), self.assertRaises(ValueError):
                 safe_path(path)


### PR DESCRIPTION
Issue #145 follow-up. Fixes root-scope verification, restores all 6493 source files byte-for-byte from the immutable v1.9.1 source, and records 6241 migrate candidates / 26,134,437 bytes. Full suite 1036 run, 5 documented skips; lifecycle 77/77. This PR intentionally does not claim the remaining 6209 HEAD deletions are complete.