### PR TITLE
chore(release): prepare v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,38 @@
 
 ## Unreleased
 
-### SRA：目标对齐与成本适配
+## v1.10.0
 
-- 主线收敛为“保护目标成立的必要投入，再比较有意义投入的风险调整后边际价值”；明确长期、难量化和未知价值不等于零，SRA 比较任务投入而非人的价值。
-- 新增采用 v0.4 输入、由哈希绑定的 `sra.proportionate.v1` 策略：结构复杂度与校准成本分开，明确低后果可逆的 Full 可使用单视图，未知、高后果及污染场景保留双视图；旧 v0.3 输入保持原有策略与重放。
-- 新增 canonical draft intake、只读决策卡、completion-only 条件引用及精确冲突诊断、显式重新分配草稿。草稿不授予权限，条件引用不证明目标正确，重排不继承旧判断或修改父运行。
-- 本次不变更 TPlan、不发版、不声明新的模型效果或 Token ROI；详见 `skills/sra/resources/proportionate-runtime.md`。
+发布 tag：`v1.10.0`
+
+[发布说明](docs/releases/v1.10.0.md)
+
+发布日期：2026-09-05
+
+### SRA Proportionate Allocation
+
+- 主线收敛为“保护目标成立的必要投入，再比较有意义投入的风险调整后边际价值”；长期、难量化和未知价值不等于零，SRA 比较任务投入而非人的价值。
+- 新增 v0.4 输入与 `sra.proportionate.v1`：结构复杂度和校准成本分开，明确低后果、可逆且无污染的 Full 可以单视图，未知、高后果及污染场景保留双视图；旧 v0.3 输入/Run 保持原有策略与重放。
+- 新增 canonical draft intake、checked Decision Card、completion criterion reference、精确冲突诊断与显式 rerank lineage；草稿不授予权限，卡片不是第二事实源，重排不继承旧判断或修改父运行。
+- Single View 只减少不必要的第二次 Agentic 判断，不绕过资源、累计 Demand、依赖、Bundle、ceiling、authority 或 finalization 校验。
+
+### 合同与维护收敛
+
+- Schema 与接收结构合同统一；依赖满足与立即资源授权显式绑定。
+- SRA / TPlan 大脚本按职责拆分，保持公共入口、事务/权限 owner 与运行时指纹边界。
+- 测试生命周期清理只迁移有明确替代 owner 的重复保护，不以数量下降作为目标。
+- 历史 benchmark per-call 材料从日常 HEAD 迁出；固定历史源仍由完整 inventory、immutable recovery ref 与 reference map 可恢复，不做 history rewrite。
+
+### 补充发布包：1.10.0 ROI Beta（GPT/Sol）
+
+- Stable release 按默认规则同步提供 `v1.10.0-roi-beta` supplemental experimental asset。
+- Beta 从精确 `v1.10.0` Stable shared core 组装并继承本版 SRA 能力；ROI runtime delta 继续限定为 SRA-compatible ROI Thin Core、历史 ROI.2 3L5S Anti-Spiral correction、独立 identity / namespace 与 diagnostic 坐标。
+- Beta-specific 自然唤醒率、相对胜率、真实任务收益和 Token ROI 未重新测量，因此不作新增模型质量或商业效果声明。
+
+### 兼容性、验证与发布资产
+
+- Stable package / plugin manifest 使用 `1.10.0`；TPlan runtime generation 继续保持 `1.5.4` / `mindthus-v1.5.4`。
+- `v1.10.0` GitHub Release 提供 `mindthus-plugins-1.10.0.tar.gz`、`mindthus-skills-1.10.0.tar.gz`、`mindthus-beta-1.10.0-roi-beta.tar.gz` 与覆盖三份归档的 `SHA256SUMS`。
 
 ## v1.9.1
 

--- a/README.md
+++ b/README.md
@@ -116,22 +116,23 @@ Host 根据自然语言自行发现并唤起 Mindthus 属于 **best-effort** 能
 
 **发布默认规则**：Stable release 默认同步提供同版本 ROI Beta supplemental asset；只有该版本在发布前明确声明例外时才不发布 ROI Beta。
 
-当前已发布 Stable 是 `v1.9.1`。这是 `v1.9.0` SRA minor release 的兼容性 Bugfix patch：
-重建并收紧 `SRA / Scarce Resource Allocation / 稀缺资源优先分配` v0.3 的资源、Bundle、
-Allocation Ledger、Reserve、Outcome / Finalization 与上下文隔离运行时合同，并关闭累计
-Demand 与 prepared-input anchor 两个最终阻断反例。它不新增方法、route 或 TPlan owner；
-TPlan 的 Mission、Pulse、继续授权和 runtime generation 仍保持原 owner 与 `1.5.4` 代际。
+当前已发布 Stable 是 `v1.10.0`。这是 **SRA / Scarce Resource Allocation / 稀缺资源优先分配 Proportionate Allocation** minor release：
+在 `v1.9.x` 已稳定的资源、依赖、授权和 Repair 合同上，让 SRA 回到“先保护目标成立所必需的投入，
+再把下一份资源分给当前风险调整后边际价值最高的用途”，并让判断成本与错误分配后果成比例。
+本版增加 v0.4 输入合同、Lite / Full 与 Single / Dual 校准解耦、输入草稿、checked Decision Card、
+完成条件引用和显式 rerank lineage；旧 v0.3 输入/Run 继续保留兼容边界。TPlan 的 Mission、Pulse、
+继续授权和 runtime generation 仍保持原 owner 与 `1.5.4` 代际。
 
-`v1.9.1` Release 同步提供 Stable plugins、Stable skills 与 ROI Beta supplemental
-experimental asset。ROI Beta 从精确 `v1.9.1` Stable shared core 组装，继承完整 SRA Skill
-和上下文隔离运行时；它的薄入口只增加经过边界校验的 SRA 分配唤起，并继续保留历史 ROI.2
-3L5S Anti-Spiral correction。Beta 使用独立 identity / namespace，不取代 Stable，也不自动迁移。
+`v1.10.0` Release 同步提供 Stable plugins、Stable skills 与 ROI Beta supplemental
+experimental asset。ROI Beta 从精确 `v1.10.0` Stable shared core 组装，继承完整 SRA 能力；
+其 runtime delta 继续限定为已资格验证的 SRA-compatible ROI Thin Core、历史 ROI.2 3L5S
+Anti-Spiral correction、Beta identity / namespace 与 diagnostic 坐标。Beta 不取代 Stable，也不自动迁移。
 
-- Codex App / Codex CLI / Claude Code 支持插件：下载 `mindthus-plugins-1.9.1.tar.gz`。
-- 不使用插件、需要 OpenCode、或只想复制 skills 目录：下载 `mindthus-skills-1.9.1.tar.gz`。
+- Codex App / Codex CLI / Claude Code 支持插件：下载 `mindthus-plugins-1.10.0.tar.gz`。
+- 不使用插件、需要 OpenCode、或只想复制 skills 目录：下载 `mindthus-skills-1.10.0.tar.gz`。
 - 只在高能力 Codex / GPT-Sol 上复查低开销唤起实验：下载
-  `mindthus-beta-1.9.1-roi-beta.tar.gz`；它使用独立的 Codex plugin / marketplace 包与
-  `mindthus-beta` 命名空间，不是通用 skills-pack，也不是 v1.9.1 Stable 的替代品。
+  `mindthus-beta-1.10.0-roi-beta.tar.gz`；它使用独立的 Codex plugin / marketplace 包与
+  `mindthus-beta` 命名空间，不是通用 skills-pack，也不是 v1.10.0 Stable 的替代品。
 
 不要在同一个 client profile 里同时安装 plugin mode 和 skills-pack mode，除非你正在测试重复 discovery。
 
@@ -141,22 +142,22 @@ experimental asset。ROI Beta 从精确 `v1.9.1` Stable shared core 组装，继
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-plugins-1.9.1.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.9.1/mindthus-plugins-1.9.1.tar.gz"
+  -o /tmp/mindthus-plugins-1.10.0.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.10.0/mindthus-plugins-1.10.0.tar.gz"
 rm -rf /tmp/mindthus-plugins
 mkdir -p /tmp/mindthus-plugins
-tar -xzf /tmp/mindthus-plugins-1.9.1.tar.gz -C /tmp/mindthus-plugins --strip-components=1
+tar -xzf /tmp/mindthus-plugins-1.10.0.tar.gz -C /tmp/mindthus-plugins --strip-components=1
 ```
 
 Skills 包，供 Codex skills-pack / Claude Code personal skills / OpenCode 使用：
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-skills-1.9.1.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.9.1/mindthus-skills-1.9.1.tar.gz"
+  -o /tmp/mindthus-skills-1.10.0.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.10.0/mindthus-skills-1.10.0.tar.gz"
 rm -rf /tmp/mindthus-skills
 mkdir -p /tmp/mindthus-skills
-tar -xzf /tmp/mindthus-skills-1.9.1.tar.gz -C /tmp/mindthus-skills --strip-components=1
+tar -xzf /tmp/mindthus-skills-1.10.0.tar.gz -C /tmp/mindthus-skills --strip-components=1
 ```
 
 ### Codex Plugin Mode（推荐）
@@ -180,20 +181,20 @@ codex plugin marketplace remove mindthus
 ### Codex ROI Beta（实验）
 
 只在高能力 Codex / GPT-Sol 上复查低开销唤起实验时使用。这个
-`v1.9.1-roi-beta` 包从精确 `v1.9.1` Stable shared core 组装，继承完整 SRA Skill、
-上下文隔离的 situated/challenge 判断运行时、Root-Cause Replacement、competitive-frame
-convergence、WAE Ownership Closure、Judgment Trace、Case Export、case-prep、Test Lifecycle
-与现有 TPlan 能力；运行时差异限定为 SRA-compatible ROI Thin Core、历史 ROI.2 单句 3L5S
-Anti-Spiral correction、Beta identity / namespace 与 diagnostic 坐标。
+`v1.10.0-roi-beta` 包从精确 `v1.10.0` Stable shared core 组装，继承完整 SRA Skill、
+v0.3/v0.4 输入兼容、比例化校准、checked Decision Card、rerank lineage、Root-Cause Replacement、
+competitive-frame convergence、WAE Ownership Closure、Judgment Trace、Case Export、case-prep、
+Test Lifecycle 与现有 TPlan 能力；运行时差异限定为 SRA-compatible ROI Thin Core、历史 ROI.2
+单句 3L5S Anti-Spiral correction、Beta identity / namespace 与 diagnostic 坐标。
 Stable 与 ROI Beta 可以独立安装或移除：
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-beta-1.9.1-roi-beta.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.9.1/mindthus-beta-1.9.1-roi-beta.tar.gz"
+  -o /tmp/mindthus-beta-1.10.0-roi-beta.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.10.0/mindthus-beta-1.10.0-roi-beta.tar.gz"
 rm -rf /tmp/mindthus-roi-beta
 mkdir -p /tmp/mindthus-roi-beta
-tar -xzf /tmp/mindthus-beta-1.9.1-roi-beta.tar.gz -C /tmp/mindthus-roi-beta --strip-components=1
+tar -xzf /tmp/mindthus-beta-1.10.0-roi-beta.tar.gz -C /tmp/mindthus-roi-beta --strip-components=1
 codex plugin marketplace add /tmp/mindthus-roi-beta
 codex plugin add mindthus-beta@mindthus-beta
 ```
@@ -312,7 +313,7 @@ python3 scripts/log-fidelity-usage.py --help
 
 ## 版本与许可
 
-当前仓库版本：`v1.9.1`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
+当前仓库版本：`v1.10.0`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
 
 Mindthus uses AGPLv3 + commercial dual licensing.
 

--- a/docs/releases/v1.10.0-roi-beta.md
+++ b/docs/releases/v1.10.0-roi-beta.md
@@ -1,0 +1,35 @@
+# Mindthus v1.10.0 ROI Beta 发布说明
+
+发布日期：2026-09-05
+
+`v1.10.0-roi-beta` 是 `v1.10.0` GitHub Release 的 supplemental experimental asset，
+与 Stable 同步发布，不是独立 Stable release，也不取代 `v1.10.0 Stable`。
+
+## 组装边界
+
+- Shared Product Core 固定为精确 `v1.10.0` Stable release commit / tree，完整继承
+  SRA Proportionate Allocation、v0.4 输入合同、completion criterion reference、checked
+  Decision Card、rerank lineage，以及 `v1.9.x` 的资源/依赖/授权/Repair 合同。
+- Runtime delta 继续使用已资格验证的 **SRA-compatible ROI Thin Core**、历史 ROI.2 单句
+  3L5S Anti-Spiral correction、Beta identity / namespace 与 diagnostic 坐标。
+- Beta overlay 不复制 Stable 的 SRA 分配逻辑，不新增 allocation owner、第二套 ledger 或
+  TPlan mutation 路径；Stable shared core 与 Beta overlay 分开验证。
+- v0.3/v0.4 输入兼容、Single/Dual 校准策略、资源与授权校验均来自精确 Stable core。
+
+## 证据上限
+
+本版 Beta 资格只覆盖 deterministic composition、shared-core identity、namespace isolation、
+packaging、runtime diagnostic 与 Stable SRA 兼容性回归。
+
+没有重新测量 Beta-specific 自然唤醒率、相对模型胜率、真实任务收益或 Token ROI，因此不作
+新的模型质量或商业效果声明。ROI Beta 的“低开销”仍是待验证产品假设，不是本发布的事实结论。
+
+## 发布形态
+
+- source tag：`v1.10.0-roi-beta`
+- GitHub Release：与 Stable 共用 `v1.10.0` Release
+- asset：`mindthus-beta-1.10.0-roi-beta.tar.gz`
+- checksum：收录于同一 Release 的 `SHA256SUMS`
+
+该归档继续使用独立 `mindthus-beta` Codex plugin / marketplace identity。需要完整 Stable
+默认行为、通用 skills-pack 或保守部署时，应安装 Stable，而不是 ROI Beta。

--- a/docs/releases/v1.10.0.md
+++ b/docs/releases/v1.10.0.md
@@ -1,0 +1,92 @@
+# Mindthus v1.10.0 发布说明
+
+发布日期：2026-09-05
+
+发布 tag：`v1.10.0`
+
+## 版本定位
+
+`v1.10.0` 是 **SRA Proportionate Allocation** minor release。
+
+本版在 `v1.9.x` 已稳定的稀缺资源、依赖、授权、上下文隔离与 Repair 合同上，重新把
+SRA 的最高目标钉在一个更直接的原则上：在目标与风险底线不变、资源有限时，以低于错误
+分配损失的判断成本，先保护目标成立所必需的投入，再把下一份资源分给当前风险调整后边际
+价值最高的用途。
+
+这不是新的优先级评分器，也不把短期、可量化收益变成唯一目标。维护、学习、长期能力、
+选择权、难量化价值与不可接受风险继续由当前目标、证据和风险边界约束。
+
+## SRA 比例化判断成本
+
+- Lite / Full 继续共享同一个 Contraction -> Replenishment 分配核心；两者的差别是值得支付的
+  分析深度，而不是两套资源逻辑。
+- 分析深度与校准成本解耦：结构复杂的 Full 不再因为“Full”本身自动要求双视图；明确低后果、
+  可逆且无污染的 Full 可以使用单视图，高后果、风险未知或受既有结论/沉没成本等污染的判断
+  继续保留独立 Challenge + Situated 校准。
+- Single View 只减少不必要的第二次 Agentic 判断，不跳过资源 contract、累计 Demand、依赖、
+  Bundle、ceiling、authority 或 finalization 校验。
+- 方向验证、瓶颈、信息增益与机会窗口被视为边际价值来源，而不是凭类别天然获得更高优先级。
+
+## v0.4 输入合同与兼容性
+
+- 新增 `sra.decision-context-input.v0.4`，用于显式携带比例化校准策略与共享完成条件引用。
+- 旧 v0.3 输入和既有 v0.3 Run 继续按原保守策略工作；新输入不会被旧 runtime 静默忽略或自动降级。
+- 新增 completion criterion reference：两个独立视图可以引用同一个来源、版本和内容哈希绑定的完成标准，
+  避免纯措辞差异触发无意义 reconciliation；真正的阈值、对象、窗口或条件变化仍保持 conflict/blocked。
+- Repair 继续只重建可验证派生产物，不把旧 Run 改写为新输入合同。
+
+## Lite 使用体验与连续重排
+
+- 新增 `draft_sra_context.py`，用于从已有明确输入生成 canonical SRA 草稿与缺口清单；它只生成确定性
+  boilerplate，不猜目标、证据、可行性、依赖满足、授权或最终优先级。
+- `render_sra_decision.py` 增加 checked Decision Card：默认先展示当前投入、授权边界、完成条件和重排触发，
+  完整 ledger / bundle / evidence / claim ceiling 仍由同一个 checked final decision 提供，卡片不是第二事实源。
+- 新增 `rerank_sra_context.py`：资源、证据、风险或窗口变化时，可以从不可变父 Run 创建新的重排草稿；
+  lineage 可追溯，但旧 priority、feasibility、dependency satisfaction、selected bundle 或 approval 不被继承。
+- SRA 仍不直接修改 TPlan Mission。Mission、Pulse、继续授权、恢复与 mutation 继续由 TPlan 拥有。
+
+## 合同修复与仓库维护收敛
+
+本 release train 同时包含 `v1.9.1` 之后完成的维护收敛：
+
+- SRA 结构 Schema 与实际接收校验统一，未知字段、缺失字段和错误形状不再被静默接受。
+- 依赖满足状态与立即资源授权绑定；把前置任务放入 Bundle 不再等同于前置已经完成。
+- SRA 与 TPlan 大脚本按职责拆分，保持公共入口、事务/锁/权限 owner 与运行时指纹边界。
+- 测试生命周期清理只移除有明确替代 owner 的重复保护，不以测试数量下降作为目标。
+- 历史 benchmark per-call 材料从日常 HEAD 迁出；6493 个固定历史源文件有完整 inventory、immutable
+  recovery ref 与 reference map，决定性报告/汇总继续保留在 HEAD。该清理降低日常搜索与索引噪音，
+  不声称显著降低完整 Git clone 历史大小。
+
+## 验证边界
+
+发版前验证覆盖：完整 unittest、Test Lifecycle、SRA 专项回归、归档 inventory/recovery/reference、
+`git diff --check`、Stable plugins/skills 全布局构建与 fresh-worktree 验证。
+
+这些结果证明当前合同、打包和回归门禁保持一致，不证明普适最优资源分配、实际商业收益、
+Beta-specific 模型质量提升或 Token ROI。
+
+## ROI Beta 同步发布
+
+Mindthus 按 Stable release 默认规则同步提供 `v1.10.0-roi-beta` supplemental experimental asset。
+Beta 从精确 `v1.10.0` Stable shared core 组装并继承本版 SRA 能力。其 runtime delta 继续限定为
+已经资格验证的 SRA-compatible ROI Thin Core、历史 ROI.2 3L5S Anti-Spiral correction、独立
+identity / namespace 与 diagnostic 坐标；本版不新增 Beta-specific 自然唤醒率、相对胜率或
+Token-ROI 声明。
+
+## 兼容性
+
+- 开发、测试与发版验证要求 CPython 3.10+；CI 使用 Python 3.11。
+- Stable plugin 和发行包 manifest 升级为 `1.10.0`。
+- TPlan runtime generation 保持 `1.5.4` / `mindthus-v1.5.4`。
+- v0.3 SRA 输入/Run 保持显式兼容；v0.4 输入使用新的版本标识，旧 reader 必须拒绝而不是忽略新字段。
+
+## 发布资产
+
+`v1.10.0` GitHub Release 提供：
+
+- `mindthus-plugins-1.10.0.tar.gz`
+- `mindthus-skills-1.10.0.tar.gz`
+- `mindthus-beta-1.10.0-roi-beta.tar.gz`
+- `SHA256SUMS`
+
+`SHA256SUMS` 覆盖三份归档。ROI Beta source tag 为 `v1.10.0-roi-beta`。

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -9,7 +9,7 @@ import shutil
 from pathlib import Path
 
 
-VERSION = "1.9.1"
+VERSION = "1.10.0"
 EXCLUDED_DIRS = {
     "__pycache__",
     ".pytest_cache",

--- a/scripts/log-mindthus-runtime.py
+++ b/scripts/log-mindthus-runtime.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 
-VERSION = "1.9.1"
+VERSION = "1.10.0"
 PACKAGE_IDENTITY = "mindthus"
 MARKETPLACE_IDENTITY = "mindthus"
 RELATIVE_FILES = (

--- a/tests/test_log_mindthus_runtime.py
+++ b/tests/test_log_mindthus_runtime.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "log-mindthus-runtime.py"
-CURRENT_VERSION = "1.9.1"
+CURRENT_VERSION = "1.10.0"
 
 
 USING_TEXT = """\

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -55,7 +55,7 @@ class PackagingDocsTests(unittest.TestCase):
             root = Path(tmp)
             out = root / "release"
             codex_home = root / "home"
-            cache = codex_home / "plugins" / "cache" / "mindthus" / "mindthus" / "1.9.1"
+            cache = codex_home / "plugins" / "cache" / "mindthus" / "mindthus" / "1.10.0"
             result = subprocess.run(
                 [sys.executable, str(script), "--package", "plugins", "--out", str(out)],
                 text=True,
@@ -642,7 +642,7 @@ class PackagingDocsTests(unittest.TestCase):
         for phrase in (
             "mindthus:tplan",
             "mindthus:*",
-            "当前仓库版本：`v1.9.1`",
+            "当前仓库版本：`v1.10.0`",
             "GitHub Releases",
             "局部正确",
             "输入定框审计",
@@ -1381,7 +1381,7 @@ class PackagingDocsTests(unittest.TestCase):
             source = marketplace["plugins"][0]["source"]
             self.assertEqual(source, "./claude-plugin")
             self.assertNotIn("..", source)
-            self.assertEqual(plugin["version"], "1.9.1")
+            self.assertEqual(plugin["version"], "1.10.0")
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "tplan" / "SKILL.md").exists())
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "mpg" / "SKILL.md").exists())
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "sra" / "SKILL.md").exists())
@@ -1480,7 +1480,7 @@ class PackagingDocsTests(unittest.TestCase):
             )
             self.assertEqual(codex_marketplace["plugins"][0]["policy"]["installation"], "AVAILABLE")
             self.assertEqual(codex_plugin_manifest["name"], "mindthus")
-            self.assertEqual(codex_plugin_manifest["version"], "1.9.1")
+            self.assertEqual(codex_plugin_manifest["version"], "1.10.0")
             self.assertEqual(codex_plugin_manifest["skills"], "./skills/")
             self.assertEqual(codex_plugin_manifest["license"], "AGPL-3.0-only")
             self.assertEqual(codex_plugin_manifest["interface"]["brandColor"], "#161614")
@@ -1604,8 +1604,8 @@ class PackagingDocsTests(unittest.TestCase):
         script = REPO / "scripts" / "build-release-pack.py"
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            plugins = tmp_dir / "mindthus-plugins-1.9.1"
-            skills = tmp_dir / "mindthus-skills-1.9.1"
+            plugins = tmp_dir / "mindthus-plugins-1.10.0"
+            skills = tmp_dir / "mindthus-skills-1.10.0"
 
             plugin_result = subprocess.run(
                 ["python3", str(script), "--package", "plugins", "--out", str(plugins)],

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -36,12 +36,12 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         self.assertIn("rather than encoded in the SPDX field", readme)
 
     def test_current_release_log_does_not_record_exact_suite_count(self):
-        release_log = (REPO / "docs" / "releases" / "v1.9.1.md").read_text(
+        release_log = (REPO / "docs" / "releases" / "v1.10.0.md").read_text(
             encoding="utf-8"
         )
         self.assertIsNone(re.search(r"\b\d+\s+tests\s+OK\b", release_log))
 
-    def test_current_v1_9_1_release_preserves_prior_roi_beta_history(self):
+    def test_current_v1_10_0_release_preserves_prior_roi_beta_history(self):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
         builder = (REPO / "scripts" / "build-release-pack.py").read_text(encoding="utf-8")
@@ -50,23 +50,22 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         release_log = (REPO / "docs" / "releases" / "v1.8.0.md").read_text(encoding="utf-8")
         beta_notes = (REPO / "docs" / "releases" / "v1.8.0-roi-beta.md").read_text(encoding="utf-8")
 
-        self.assertIn("当前仓库版本：`v1.9.1`", readme)
+        self.assertIn("当前仓库版本：`v1.10.0`", readme)
         self.assertEqual(readme.count("当前仓库版本："), 1)
-        self.assertIn("当前已发布 Stable 是 `v1.9.1`", readme)
-        self.assertIn("mindthus-plugins-1.9.1.tar.gz", readme)
-        self.assertIn("mindthus-skills-1.9.1.tar.gz", readme)
-        self.assertIn("mindthus-beta-1.9.1-roi-beta.tar.gz", readme)
+        self.assertIn("当前已发布 Stable 是 `v1.10.0`", readme)
+        self.assertIn("mindthus-plugins-1.10.0.tar.gz", readme)
+        self.assertIn("mindthus-skills-1.10.0.tar.gz", readme)
+        self.assertIn("mindthus-beta-1.10.0-roi-beta.tar.gz", readme)
         self.assertIn("Scarce Resource Allocation", readme)
+        self.assertIn("## v1.10.0", changelog)
+        self.assertIn("补充发布包：1.10.0 ROI Beta", changelog)
+        self.assertIn("v1.10.0-roi-beta", changelog)
         self.assertIn("## v1.9.1", changelog)
+        self.assertIn("## v1.8.0", changelog)
         self.assertIn("补充发布包：1.9.1 ROI Beta", changelog)
         self.assertIn("v1.9.1-roi-beta", changelog)
-        self.assertIn("## v1.8.0", changelog)
-        self.assertIn("## v1.7.1", changelog)
-        self.assertIn("## v1.7.0", changelog)
-        self.assertIn("补充发布包：1.8.0 ROI Beta", changelog)
-        self.assertIn("v1.8.0-roi-beta", changelog)
-        self.assertIn('VERSION = "1.9.1"', builder)
-        self.assertIn('VERSION = "1.9.1"', runtime_logger)
+        self.assertIn('VERSION = "1.10.0"', builder)
+        self.assertIn('VERSION = "1.10.0"', runtime_logger)
         self.assertIn('"package_version": "1.5.4"', tplan_manifest)
         self.assertIn('"source_id": "mindthus-v1.5.4"', tplan_manifest)
         for phrase in (
@@ -89,9 +88,9 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
 
     def test_release_defaults_publish_roi_beta_unless_explicitly_exempted(self):
         policy = (REPO / "docs" / "internal" / "release-defaults.md").read_text(encoding="utf-8")
-        release = (REPO / "docs" / "releases" / "v1.9.1.md").read_text(encoding="utf-8")
-        beta = (REPO / "docs" / "releases" / "v1.9.1-roi-beta.md").read_text(encoding="utf-8")
-        prior_beta = (REPO / "docs" / "releases" / "v1.8.0-roi-beta.md").read_text(encoding="utf-8")
+        release = (REPO / "docs" / "releases" / "v1.10.0.md").read_text(encoding="utf-8")
+        beta = (REPO / "docs" / "releases" / "v1.10.0-roi-beta.md").read_text(encoding="utf-8")
+        prior_beta = (REPO / "docs" / "releases" / "v1.9.1-roi-beta.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
         for phrase in (
             "Stable release 默认同步发布同版本 ROI Beta",
@@ -100,14 +99,14 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, policy)
         self.assertIn("ROI Beta 同步发布", release)
-        self.assertIn("mindthus-plugins-1.9.1.tar.gz", release)
-        self.assertIn("mindthus-skills-1.9.1.tar.gz", release)
-        self.assertIn("mindthus-beta-1.9.1-roi-beta.tar.gz", release)
-        self.assertIn("v1.9.1-roi-beta", beta)
+        self.assertIn("mindthus-plugins-1.10.0.tar.gz", release)
+        self.assertIn("mindthus-skills-1.10.0.tar.gz", release)
+        self.assertIn("mindthus-beta-1.10.0-roi-beta.tar.gz", release)
+        self.assertIn("v1.10.0-roi-beta", beta)
         self.assertIn("SRA-compatible ROI Thin Core", beta)
         self.assertIn("Beta-specific", beta)
-        self.assertIn("v1.8.0-roi-beta", prior_beta)
-        self.assertIn("补充发布包：1.9.1 ROI Beta", changelog)
+        self.assertIn("v1.9.1-roi-beta", prior_beta)
+        self.assertIn("补充发布包：1.10.0 ROI Beta", changelog)
         self.assertIn("覆盖三份归档的 `SHA256SUMS`", changelog)
 
     def test_v1_4_6_release_surface_is_preserved(self):

--- a/tests/test_v1_0_1_usage_log.py
+++ b/tests/test_v1_0_1_usage_log.py
@@ -274,7 +274,7 @@ class V101UsageLogTests(unittest.TestCase):
         )
 
         for phrase in (
-            "当前仓库版本：`v1.9.1`",
+            "当前仓库版本：`v1.10.0`",
             "scripts/log-fidelity-usage.py",
             "data/fidelity-usage-log.jsonl",
             "可选：记录使用效果",
@@ -304,7 +304,7 @@ class V101UsageLogTests(unittest.TestCase):
                     / "plugin.json"
                 ).read_text(encoding="utf-8")
             )
-            self.assertEqual(plugin["version"], "1.9.1")
+            self.assertEqual(plugin["version"], "1.10.0")
             for platform_root in (
                 root / "claude-code" / "claude-plugin",
                 root / "codex",


### PR DESCRIPTION
Prepare Mindthus v1.10.0 SRA Proportionate Allocation release surfaces. Bumps Stable package/runtime diagnostic version to 1.10.0, adds Stable and ROI Beta release notes, updates README/CHANGELOG and release-boundary tests. No tag or GitHub Release is created by this PR.