### PR TITLE
docs(release): verify v1.10.0 publication

### DIFF
--- a/docs/internal/audits/2026-09-05-v1.10.0-release-verification.md
+++ b/docs/internal/audits/2026-09-05-v1.10.0-release-verification.md
@@ -1,0 +1,129 @@
+# Mindthus v1.10.0 Release Verification
+
+Date: 2026-09-05
+
+Status: **PASS — publication verified**
+
+This record is post-publication evidence. It is intentionally outside the frozen Stable
+and ROI Beta source tags and does not move either tag.
+
+## Stable source identity
+
+- source tag: `v1.10.0`
+- annotated tag object: `aa1d79a58c5ea865c85a7d7a5414158fe217df82`
+- peeled release commit: `facc26ebac7004700881bd45f60e33960a197761`
+- release tree: `c00780d3c43086378e10bd51521c5453212bc8b0`
+- release-prep PR: #193, CI `unittest-smoke` SUCCESS before merge
+
+The tag was created only after the exact merged source passed the release gates. It was
+not moved after publication.
+
+## Stable release gates
+
+On the exact peeled Stable source:
+
+- SRA focused regression: 124 tests passed;
+- complete unittest discovery: 1054 tests ran and passed with 5 documented optional-dependency skips;
+- Test Lifecycle: 78/78 executable test files registered, `status=valid`;
+- `git diff --check`: pass;
+- Stable plugins and skills each built twice independently and were byte-identical;
+- packaged Python surfaces compiled successfully.
+
+Stable archive SHA-256:
+
+- `mindthus-plugins-1.10.0.tar.gz`:
+  `8fbcf62c9e65e91ba56d8ffaa23fd2436afa74288247e4134978a24fb00c8bc5`
+- `mindthus-skills-1.10.0.tar.gz`:
+  `ecf3d53c42ca1c0fa9f2d4311aedf75be2b094961b5957982b47bdddf99cc702`
+
+## ROI Beta source identity
+
+- source tag: `v1.10.0-roi-beta`
+- annotated tag object: `f2566eb60f4bcf3c9cace44e5ef7f421ff8efba4`
+- peeled Beta source commit: `9b563f8973119e6b4d42ca13fd28b79c084226b5`
+- Beta source tree: `e3a7125c0a87757ea65a4768a76906c3e46922f1`
+- exact Stable shared core: `facc26ebac7004700881bd45f60e33960a197761`
+- Stable shared-core tree: `c00780d3c43086378e10bd51521c5453212bc8b0`
+- deterministic compatibility qualification:
+  `bba86f751c4c80b0117787969e5ff5fcb695f3bb`
+- frozen ROI Thin Core implementation:
+  `0bd58701fd36f33d5640ff2d00aa5e208026dbfa`
+- frozen Thin Core size: 2274 bytes
+
+The Beta source descends from the prior ROI Beta source and merges the exact `v1.10.0`
+Stable source. Stable product changes therefore enter Beta through shared-core ancestry;
+Beta-specific runtime deltas remain isolated to the previously qualified Thin Core,
+historical ROI.2 3L5S correction, Beta identity/namespace and runtime diagnostic.
+
+## ROI Beta gates
+
+The v1.10.0 deterministic SRA compatibility qualification passed and verified:
+
+- exact Stable commit/tree inheritance;
+- `mindthus-beta` identity and namespace isolation;
+- byte equality of all non-declared-delta shared-core plugin files after namespace normalization;
+- inherited v1.9.x cumulative Demand, dependency-authorization and prepared-input Repair boundaries;
+- inherited `sra.decision-context-input.v0.4` and `sra.proportionate.v1` identities;
+- inherited proportionate runtime, completion criteria, checked-card/intake and rerank surfaces;
+- explicit legacy v0.3 compatibility / v0.4 version-boundary regressions;
+- deterministic two-build archive reproducibility.
+
+On the final Beta source, complete unittest discovery ran 1054 tests and passed with 5
+documented optional-dependency skips. Test Lifecycle remained 78/78 valid. Packaged
+Python compiled successfully. The Beta runtime diagnostic returned `status=ok` under
+`--strict` when repo/marketplace/cache roots were explicitly bound to the same inspectable
+built artifact; this checks file/hash/marker integrity, not real-host activation.
+
+Final ROI Beta archive SHA-256:
+
+- `mindthus-beta-1.10.0-roi-beta.tar.gz`:
+  `5c4289d151136ad193a2a620af06929f3981e104ceccd9ff886cddec4d14633d`
+
+## GitHub Release publication
+
+GitHub Release:
+
+- tag: `v1.10.0`
+- title: `Mindthus v1.10.0`
+- published: `2026-09-05T08:23:40Z`
+- draft: false
+- prerelease: false
+- Latest: yes
+
+Published assets:
+
+| Asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `mindthus-plugins-1.10.0.tar.gz` | 1,344,652 | `8fbcf62c9e65e91ba56d8ffaa23fd2436afa74288247e4134978a24fb00c8bc5` |
+| `mindthus-skills-1.10.0.tar.gz` | 2,024,691 | `ecf3d53c42ca1c0fa9f2d4311aedf75be2b094961b5957982b47bdddf99cc702` |
+| `mindthus-beta-1.10.0-roi-beta.tar.gz` | 667,426 | `5c4289d151136ad193a2a620af06929f3981e104ceccd9ff886cddec4d14633d` |
+| `SHA256SUMS` | 296 | `38dc7429e952d53a79ea10480d046f421327723a0f194d3b7cd4e9f1d63f791f` |
+
+All four assets were downloaded again from the published GitHub Release into a fresh
+directory. `sha256sum -c SHA256SUMS` passed for all three archives, and each downloaded
+file was byte-identical to its pre-upload frozen artifact.
+
+Archive inspection confirmed:
+
+- Stable Codex plugin identity/version: `mindthus` / `1.10.0`;
+- ROI Beta plugin identity/version: `mindthus-beta` / `1.10.0-roi-beta`;
+- packaged Beta profile binds Stable ref/tree exactly to the values above;
+- packaged Beta `assembly_source_ref` is exactly
+  `9b563f8973119e6b4d42ca13fd28b79c084226b5`;
+- packaged Beta `qualification_ref` is exactly
+  `bba86f751c4c80b0117787969e5ff5fcb695f3bb`.
+
+## Claim ceiling
+
+This verification proves the named source identities, deterministic release gates,
+packaging/composition boundaries, archive reproducibility, publication state and
+post-download checksums.
+
+It does not prove universal SRA allocation correctness, Beta-specific natural activation,
+relative model quality, real-task benefit, cross-host behavioral parity or Token ROI.
+Those remain separate evidence questions and are not release claims for v1.10.0.
+
+## Verdict
+
+`v1.10.0 Stable` and synchronized `v1.10.0-roi-beta` are published and verified. No
+release blocker remains in the publication contract covered by this record.


### PR DESCRIPTION
Post-publication verification for v1.10.0 Stable and synchronized ROI Beta. Records frozen tag/source/tree identities, deterministic build gates, published asset digests, fresh-download checksum verification, and explicit claim ceiling. Does not move release tags or change product code.