### PR TITLE
fix(tplan): enforce evidence, activation, continuation and completion integrity

### DIFF
--- a/docs/internal/audits/2026-09-05-tplan-authority-contract-implementation-review.md
+++ b/docs/internal/audits/2026-09-05-tplan-authority-contract-implementation-review.md
@@ -1,0 +1,166 @@
+# TPlan Authority Contract Repairs — Implementation Review
+
+Date: 2026-09-05
+Scope: #196, #197, #199, #198, in that implementation order.
+Design: [frozen repair audit](2026-09-05-tplan-authority-contract-repair-audit.md).
+Base: `33e66ad801cee70223ef3d4a931adebc22970a38`.
+Final product/test candidate: `45c0ac0b1cdc80465deeb2accba5ad80bf919535`.
+Candidate tree: `ec4be361f97780563678c387fc4d5cda35eb2a85`.
+Verdict: **PASS for the four frozen deterministic repair contracts; ready for PR review.**
+Merge and release are separate actions. #200 remains design-only.
+
+## 1. Review method and evidence boundary
+
+The implementing ChatGPT first wrote failing regressions, applied each repair, ran
+focused and repository tests, and then reviewed alternate entry points and failure
+boundaries. Review found two additional entry-point gaps, which were reproduced and
+fixed before final validation in a fresh worktree at the candidate above.
+
+This is same-assistant implementation review with isolated execution verification,
+not an independent-model or fresh-Agent certification. No external reviewer CLI was
+used. The original incident archive and admitted observations remain unchanged.
+
+The test module `tests/tplan/test_authority_integrity.py` groups 30 regression methods
+under the existing TPlan lifecycle owner. Subtests exercise multiple statuses and
+mutation forms; they are not reported as additional real-use samples.
+
+## 2. Delivered invariants
+
+| Issue | Enforcement | Positive/compatibility controls |
+| --- | --- | --- |
+| #196 | New typed evidence references resolve uniquely against the locked Mission evidence plus same-transaction prepared events before journaling. Standalone trace append reuses the resolver. | Existing and prepared IDs work; artifact refs stay separate; unrelated writes can proceed despite unreferenced historical duplicates. |
+| #197 | `add_task_node(status=active)` shares `set_task_status(active)` before one transaction. | Pending additions preserve the cursor; active ancestor/selected leaf and blocked recovery cursor remain supported. |
+| #199 | One pure consequence validator is called by the existing shared hook-output validator. Stop/review/audit ceilings reject continue/switch/add and execution-widening/completion mutations. | Consistent continue, targeted fix, batching, narrowing stop and advisory review remain possible; weak ROI/lint is not an automatic stop oracle. |
+| #198 | A new Mission completion checks every success-critical node and the latest qualified observation for every acceptance ID under the existing lock. | Stream order, complete legacy acceptance, same-transaction evidence, unfinished supporting work and advisory recommendations remain supported. |
+
+The completion helper uses existing acceptance IDs and evidence events. It introduces
+no new acceptance schema or reviewer registry. Missing, wrong-scope, ambiguous-ID or
+incomplete observations cannot supply qualified positive acceptance. A qualified
+failure later in stream order blocks closure; a later qualified positive observation
+can satisfy that condition again. This is not semantic verification of the claim.
+
+## 3. Red-to-green evidence
+
+The original missing-reference and dynamic-activation scenarios failed the new expected
+outcome tests before their respective repairs. The continuation matrix reproduced
+stop/review plus activation under ordinary application and a correctly bound Guard
+receipt. The completion tests reproduced missing acceptance, unfinished critical work,
+late adverse evidence and receipt-bound premature closure.
+
+After core implementation, the first whole-TPlan run found seven old fixture failures:
+completion helper paths supplied no qualified acceptance, and a lifecycle test referred
+to a nonexistent `E-acceptance`. The two existing fixture owners were corrected to
+append explicit fixture acceptance events. Their renderer/lifecycle assertions were
+preserved. Production checks were not relaxed to accommodate those fixtures.
+
+First whole-repository self-test after those corrections:
+
+- 1077 tests run; 1072 passed; 5 existing optional-dependency skips.
+- 79/79 executable test files registered by the existing lifecycle registry glob.
+
+## 4. Review findings and resolution
+
+### R1 — Compatibility writer bypassed canonical completion checks
+
+`write_mission()` described itself as initialization/test compatibility support, but
+its existing-Mission branch could directly replace a live snapshot without the
+transaction gate or lifecycle effects. A new review regression reproduced premature
+completion and the absence of a completion trace.
+
+Resolution: existing-state writes delegate to `_commit_mission_state_unlocked()` under
+the existing lock, retaining the explicit Guard prohibition. The same reference,
+completion, provenance and lifecycle rules now apply. No second closure check was
+created in the compatibility writer. Initial snapshot creation remains a separate
+initializer, not a semantic acceptance certification or historical import verifier.
+
+### R2 — Standalone trace append accepted dangling evidence IDs
+
+The standalone append API could persist lifecycle references without going through the
+state transaction. The review regression reproduced a dangling typed evidence ID.
+
+Resolution: the append path reuses `_validate_trace_evidence_references()` after shape
+validation and under its existing lock. Its supported-write/provenance preparation
+runs after input validation and before persistence. The contextual resolver is not
+moved into the pure trace-shape validator.
+
+These are integration completions of the frozen invariants, not new authority systems.
+
+### Historical diagnostics
+
+`check_mission.py` reads one locked attribution snapshot after its existing pending
+recovery step, then reports `integrity_warning` for unresolved historical references
+or a currently unsupported historical completion claim. Warnings do not rewrite the
+files or certify acceptance. Shape-check success is explicitly separate from new
+completion eligibility. The new test verifies both warnings and byte preservation.
+
+## 5. Final executable verification
+
+All results below bind to the clean product/test candidate named above, not the earlier
+working-tree state.
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -q
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.tplan.test_authority_integrity -q
+python3 scripts/check-test-lifecycle.py --json
+git diff --check
+PYTHONDONTWRITEBYTECODE=1 python3 data/cases/slidethus-vq-execution-overrun-20260905/reproduce.py
+python3 scripts/build-release-pack.py --out <new-temp-directory>/pack --package all
+```
+
+Environment: CPython 3.10.12; fresh detached worktree.
+
+| Check | Observed result |
+| --- | --- |
+| Complete repository suite | 1084 run / 1079 passed / 5 existing optional skips / 0 failures |
+| New authority regression module | 30/30 passed |
+| Lifecycle registry | 79/79 executable files registered, valid, no findings |
+| Git whitespace and fresh worktree | Clean |
+| Original bounded packet | 10/10 source file hashes matched; original consent flags preserved |
+| Original current-runtime probes | Missing/path-as-evidence refs rejected with no writes; active T6 has matching cursor/event; premature Mission completion rejected with no writes; stop/activation contradiction rejected with no writes |
+| Legal probe controls | Existing evidence, artifact refs, pending creation and ordinary activation accepted |
+| All release layouts | Built; both changed runtime/check scripts present in all five layouts and byte-identical to source |
+| Isolated packaged Python processes | Five imports, provenance fingerprints and deterministic contract probes passed |
+
+Packaged script SHA-256:
+
+- `tplan_runtime.py`: `fa79ca946eda57ed167928e9e1a599872eec1a1aee8c646a7c8d4729b0c354fd`
+- `check_mission.py`: `54297a88b53bac22120d252ab2553c7d5b75f15dc4e75cbad862c3eaf3724c0a`
+
+The first package-import verification invocation passed a string to
+`runtime_fingerprint`, which expects `Path`. That verification command was corrected;
+all five isolated checks then passed. No product change was made for that invocation
+error. Build success is not being used as a substitute for the subsequent import tests.
+
+## 6. Atomicity, concurrency and compatibility review
+
+- Rejected new refs, contradictory decisions and ineligible closures leave snapshots,
+  trace, evidence and Guard state unchanged in clean fixtures.
+- Same-transaction evidence can support the transaction that commits it.
+- A journal preparation failure does not leave an orphan node or partial cursor.
+- Interrupted qualified closure recovers once from prepared contents; repeated recovery
+  leaves stable bytes and exactly one applied decision event.
+- Failure appended before commit-lock acquisition prevents closure. A concurrent append
+  attempted while closure holds the lock waits until that transaction commits; its
+  later failure remains visible and invalidates current qualification, rather than
+  being misrepresented as evidence that was available earlier.
+- A genuine bound Guard receipt cannot override either completion or continuation
+  contradictions; a valid guarded closure succeeds and releases the Guard.
+- Existing provenance, Guard, persistence, renderer and installed-runtime regressions
+  were included in final repository verification.
+- Frozen legacy pending transactions retain their existing recovery behavior. Historical
+  reads do not acquire a new verified-acceptance status, and no automatic migration or
+  fingerprint rewriting was introduced.
+
+## 7. Claim ceiling and remaining work
+
+This repair establishes the stated deterministic consistency at the covered supported
+APIs. It does not prove visual quality, model judgment, the truth of an acceptance
+assertion, or an exact historical cause for the Slidethus overrun.
+
+The Codex App / Sol High 16-hour task was not rerun. No claim is made about recovered
+hours, Token ROI, hook activation, or prevention of arbitrary external provider calls.
+#200 external continuation scope, #140 native enforcement and existing platform E2E
+issues keep their separate ownership and approval boundaries.
+
+No SRA method change, new scheduler, new host hook, global budget threshold, release
+version update, tag movement or publishing action is included.

--- a/docs/internal/issues/tplan-execution-overrun-remediation-20260905.md
+++ b/docs/internal/issues/tplan-execution-overrun-remediation-20260905.md
@@ -1,9 +1,10 @@
 # TPlan 执行过载案例：合同修复与接入方案
 
 Date: 2026-09-05
-Status: evidence admitted; #196–#200 registered; repair contract audited and frozen; runtime implementation not yet performed.
+Status: #196/#197/#199/#198 implemented and self-tested in candidate `45c0ac0b1cdc80465deeb2accba5ad80bf919535`; implementation review passed; merge/release pending. #200 remains design-only.
 Original reproduction base: `407112ded87377b5b7dd351c49dd0d20b1d598d4` (TPlan source identical to v1.10.0).
 Repair audit: `docs/internal/audits/2026-09-05-tplan-authority-contract-repair-audit.md` on `2501e8ac3f55b24478abefa68b864f8472744af0`.
+Implementation review: [four-contract repairs and final verification](../audits/2026-09-05-tplan-authority-contract-implementation-review.md).
 
 案例：[RU-20260905-SLIDETHUS-VQ-OVERRUN-01](../../../data/cases/slidethus-vq-execution-overrun-20260905/README.md)。
 复现：[reproduce.py](../../../data/cases/slidethus-vq-execution-overrun-20260905/reproduce.py)；
@@ -206,10 +207,10 @@ provenance、稀疏呈现和re-entry，不把本次新问题混成这些旧issue
 
 | 项目 | Issue | 状态 |
 |---|---|---|
-| R1 事务内证据引用解析 | #196 | P1缺陷已复现，待修复 |
-| R2 创建/激活与活动游标原子一致 | #197 | P1缺陷已复现，待修复 |
-| R3 Mission完成前置与验收范围 | #198 | P1矛盾已复现，关闭合同需先评审 |
-| R4 续行授权与实际mutation一致 | #199 | P1缺陷已复现，待修复 |
+| R1 事务内证据引用解析 | #196 | 已实现、自测及评审通过，待合并 |
+| R2 创建/激活与活动游标原子一致 | #197 | 已实现、自测及评审通过，待合并 |
+| R3 Mission完成前置与验收范围 | #198 | 冻结的最小关闭合同已实现及验证，待合并 |
+| R4 续行授权与实际mutation一致 | #199 | 已实现、自测及评审通过，待合并 |
 | D1 外部受管执行与跨root续投边界 | #200 | 设计/验证候选，未批准实施 |
 
 父证据入口复用#144，不新增一个大总纲。#144已补入库记录和分母排除说明。

--- a/skills/tplan/resources/hooks.md
+++ b/skills/tplan/resources/hooks.md
@@ -272,6 +272,14 @@ separate pressure-case-specific lint, generation, rerun, or defect-queue workflo
 }
 ```
 
+The shared decision validator treats `stop`, `mission_review`, and `anti_spiral_audit`
+as non-execution ceilings. They permit a consistent escalation/closure/subtraction
+record and narrowing state changes (pause, block, or non-completion exit), while
+rejecting activation, re-queueing, completion, or an outer continue/switch/add request.
+Both ordinary and receipt-bound Guard application use this rule. A recorded no-mutation
+review request is not evidence that a review ran or that an external process stopped.
+Qualitative ROI, lint and evidence-delta values remain inputs to Agentic judgment.
+
 count-based reminders are triggers, not decisions. A third touch, repeated same-path
 attempt, post-continuation defect, repeated negative feedback, high-cost or
 high-blast-radius continuation, or weak evidence delta only routes the decision into

--- a/skills/tplan/resources/lifecycle.md
+++ b/skills/tplan/resources/lifecycle.md
@@ -56,6 +56,13 @@ those canonical artifacts change. Run `scripts/runtime_doctor.py` when selection
 uncertain; the complete compatibility and recovery contract is in
 `runtime-provenance.md`.
 
+Before a new lifecycle transaction is journaled, its `refs.evidence_ids` resolve
+uniquely against the locked Mission evidence stream plus that transaction's prepared
+events. Artifact paths belong in `artifact_refs`. Historical references remain intact;
+only references used by the new transaction must resolve. Reference existence is a
+structural property, separate from acceptance sufficiency. Recovery replays the
+already-prepared transaction contents rather than reinterpreting later evidence.
+
 ## Decision State
 
 decision state records PM choices such as split, prune, downgrade, abandon, switch, and

--- a/skills/tplan/resources/lifecycle.md
+++ b/skills/tplan/resources/lifecycle.md
@@ -5,6 +5,21 @@
 A Mission is `completed` only when every success-critical Task node is completed and
 Mission acceptance evidence is satisfied.
 
+Each new transition into Mission `completed` checks these prerequisites inside the
+existing transaction lock, before the journal is written. Every node marked
+`success-critical` must be completed. For each declared Mission acceptance ID, the
+latest mechanically qualified observation in evidence-stream order must be
+`acceptance_passed` or a complete compatible legacy `acceptance`; a later
+`acceptance_failed` blocks closure until a later qualified positive observation.
+Existing evidence and same-transaction prepared evidence form one snapshot. Duplicate
+IDs and invalid/wrong-scope observations cannot supply qualified acceptance.
+
+The gate checks declared references and pass/fail observations, not deliverable quality
+or reviewer correctness. Ordinary Task completion stays lightweight and does not itself
+satisfy Mission acceptance. Historical completed records remain readable; new closure
+checks do not backfill or certify their past acceptance. Recovery preserves frozen
+pending transaction contents rather than applying new semantic judgments to history.
+
 If remaining tasks are not worth executing, the Mission is closed under a non-completion
 terminal state.
 

--- a/skills/tplan/resources/lifecycle.md
+++ b/skills/tplan/resources/lifecycle.md
@@ -75,8 +75,16 @@ Before a new lifecycle transaction is journaled, its `refs.evidence_ids` resolve
 uniquely against the locked Mission evidence stream plus that transaction's prepared
 events. Artifact paths belong in `artifact_refs`. Historical references remain intact;
 only references used by the new transaction must resolve. Reference existence is a
-structural property, separate from acceptance sufficiency. Recovery replays the
-already-prepared transaction contents rather than reinterpreting later evidence.
+structural property, separate from acceptance sufficiency. Standalone trace append
+uses the same resolver under its existing lock. The compatibility `write_mission`
+entry delegates updates of an existing Mission to the canonical transaction boundary.
+Recovery replays the already-prepared transaction contents rather than reinterpreting
+later evidence.
+
+`check_mission.py` reports historical unresolvable references and unsupported current
+completion claims as `integrity_warning` diagnostics from one locked snapshot. These
+warnings preserve historical files and do not certify their acceptance. Its successful
+shape-check exit is separate from the prerequisites for a new completion write.
 
 ## Decision State
 

--- a/skills/tplan/scripts/check_mission.py
+++ b/skills/tplan/scripts/check_mission.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Validate a tplan Mission runtime state.
 
-This checks runtime shape and acceptance evidence coverage only. It does not judge
-Mission value or semantic correctness.
+This checks runtime shape and reports historical reference/closure inconsistencies.
+It does not judge Mission value or semantic correctness.
 """
 
 from __future__ import annotations
@@ -13,8 +13,10 @@ from pathlib import Path
 
 from tplan_runtime import (
     TplanError,
-    read_execution_trace,
+    _mission_completion_findings,
+    _validate_trace_evidence_references,
     read_mission,
+    read_outcome_attribution_snapshot,
     runtime_provenance_report,
     validate_execution_trace,
     validate_mission,
@@ -32,11 +34,18 @@ def main() -> int:
     args = parse_args()
     mission_dir = Path(args.mission_dir)
     runtime_report = None
+    integrity_warnings = []
     try:
-        mission = read_mission(mission_dir)
+        read_mission(mission_dir)  # Preserve the check command's pending-recovery behavior.
+        snapshot = read_outcome_attribution_snapshot(mission_dir)
+        mission, trace, events = snapshot["mission"], snapshot["trace"], snapshot["events"]
         errors = validate_mission(mission)
         errors.extend(validate_mission_directory_identity(mission, mission_dir))
-        errors.extend(validate_execution_trace(mission, read_execution_trace(mission_dir)))
+        errors.extend(validate_execution_trace(mission, trace))
+        if not errors:
+            integrity_warnings.extend(_validate_trace_evidence_references(trace, events))
+            if mission["mission"]["status"] == "completed":
+                integrity_warnings.extend(_mission_completion_findings(mission, events))
         runtime_report = runtime_provenance_report(mission)
         if runtime_report["severity"] == "error":
             errors.extend(
@@ -54,6 +63,8 @@ def main() -> int:
         return 1
 
     print("mission_check: ok")
+    for warning in integrity_warnings:
+        print(f"integrity_warning: {warning}")
     if runtime_report is not None and runtime_report["severity"] == "warning":
         for item in runtime_report["diagnostics"]:
             print(f"runtime_warning: {item['code']}: {item['message']}")

--- a/skills/tplan/scripts/tplan_runtime.py
+++ b/skills/tplan/scripts/tplan_runtime.py
@@ -1837,6 +1837,8 @@ def add_task_node(mission_dir: Path, raw: dict[str, Any]) -> dict[str, Any]:
     node = normalize_task_for_mission(mission, raw)
     updated = copy.deepcopy(mission)
     updated["tasks"] = list(mission.get("tasks", [])) + [node]
+    if node["status"] == "active":
+        set_task_status(updated, node["id"], "active")
     commit_mission_state(
         mission_dir,
         mission,

--- a/skills/tplan/scripts/tplan_runtime.py
+++ b/skills/tplan/scripts/tplan_runtime.py
@@ -3272,6 +3272,26 @@ def _validate_new_evidence_ids_unlocked(
     return errors
 
 
+def _validate_trace_evidence_references(
+    records: list[dict[str, Any]], events: list[dict[str, Any]]
+) -> list[str]:
+    """Resolve typed IDs against one supplied evidence snapshot, without changing it."""
+    counts = Counter(
+        event.get("id") for event in events
+        if isinstance(event, dict) and isinstance(event.get("id"), str)
+    )
+    referenced = {
+        evidence_id
+        for record in records
+        for evidence_id in record.get("refs", {}).get("evidence_ids", [])
+    }
+    return [
+        f"evidence reference {evidence_id!r} must resolve to exactly one Mission event "
+        f"(found {counts[evidence_id]})"
+        for evidence_id in sorted(referenced) if counts[evidence_id] != 1
+    ]
+
+
 def prepare_event(mission_dir: Path, event: dict[str, Any]) -> dict[str, Any]:
     event = dict(event)
     event.setdefault("id", _next_event_id(mission_dir))
@@ -4001,6 +4021,11 @@ def _commit_mission_state_unlocked(
         errors = validate_execution_trace_record(after, record)
         if errors:
             raise TplanError("; ".join(errors))
+
+    evidence_snapshot = _read_events_unlocked(mission_dir) + list(prepared_evidence_events or [])
+    reference_errors = _validate_trace_evidence_references(records, evidence_snapshot)
+    if reference_errors:
+        raise TplanError("; ".join(reference_errors))
 
     paths = mission_paths(mission_dir)
     previous_trace = paths["trace"].read_text(encoding="utf-8") if paths["trace"].exists() else ""

--- a/skills/tplan/scripts/tplan_runtime.py
+++ b/skills/tplan/scripts/tplan_runtime.py
@@ -838,11 +838,10 @@ def sync_mission_narrative(
 
 
 def write_mission(mission_dir: Path, data: dict[str, Any], *, latest_state: str | None = None) -> None:
-    """Write initial Mission state, but never bypass an open interaction guard.
+    """Initialize a Mission; existing-state writes share the canonical commit boundary.
 
-    Runtime mutations must use ``commit_mission_state``.  This compatibility writer
-    remains for initialization and tests; once a Mission has a guard, it is deliberately
-    fail-closed so a supported API cannot silently alter the protected baseline.
+    The compatibility entry retains its guard restriction and uses the same reference,
+    completion, provenance and lifecycle checks as ordinary runtime mutations.
     """
 
     paths = mission_paths(mission_dir)
@@ -852,14 +851,11 @@ def write_mission(mission_dir: Path, data: dict[str, Any], *, latest_state: str 
             if _read_interaction_guard_unlocked(mission_dir) is not None:
                 raise TplanError("interaction guard is open; write_mission cannot bypass protected Mission state")
             before = _read_mission_unlocked(mission_dir)
-            prepared = copy.deepcopy(data)
-            _prepare_runtime_provenance(
-                before,
-                prepared,
-                allow_legacy_adoption=True,
+            _commit_mission_state_unlocked(
+                mission_dir, before, copy.deepcopy(data),
+                source={"kind": "runtime_script", "name": "write_mission"},
+                latest_state=latest_state,
             )
-            write_json(paths["mission"], prepared)
-            sync_mission_narrative(mission_dir, prepared, latest_state=latest_state)
         return
     prepared = copy.deepcopy(data)
     prepared.setdefault("runtime_provenance", new_runtime_provenance())
@@ -3824,6 +3820,9 @@ def _append_execution_trace_record_unlocked(mission_dir: Path, record: dict[str,
     if errors:
         raise TplanError("; ".join(errors))
 
+    reference_errors = _validate_trace_evidence_references([normalized], _read_events_unlocked(mission_dir))
+    if reference_errors:
+        raise TplanError("; ".join(reference_errors))
     existing = _read_execution_trace_unlocked(mission_dir)
     event_id = normalized["event_id"]
     if any(item.get("event_id") == event_id for item in existing):
@@ -3843,6 +3842,9 @@ def _append_execution_trace_record_unlocked(mission_dir: Path, record: dict[str,
         if observed_at < mission_started:
             raise TplanError("execution trace span event must not precede Mission initialization")
 
+    _prepare_supported_runtime_write_unlocked(
+        mission_dir, operation="append_execution_trace_record",
+    )
     path = mission_paths(mission_dir)["trace"]
     previous = path.read_text(encoding="utf-8") if path.exists() else ""
     if previous and not previous.endswith("\n"):
@@ -3854,10 +3856,6 @@ def _append_execution_trace_record_unlocked(mission_dir: Path, record: dict[str,
 def append_execution_trace_record(mission_dir: Path, record: dict[str, Any]) -> dict[str, Any]:
     with execution_trace_lock(mission_dir):
         _recover_pending_mission_transaction_unlocked(mission_dir)
-        _prepare_supported_runtime_write_unlocked(
-            mission_dir,
-            operation="append_execution_trace_record",
-        )
         return _append_execution_trace_record_unlocked(mission_dir, record)
 
 

--- a/skills/tplan/scripts/tplan_runtime.py
+++ b/skills/tplan/scripts/tplan_runtime.py
@@ -6148,6 +6148,41 @@ def _validate_continuation_authorization(decision: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _validate_decision_consequences(decision: dict[str, Any]) -> list[str]:
+    """Enforce explicit stop/review ceilings without grading ROI or evidence quality."""
+    authorization = decision.get("continuation_authorization")
+    if not isinstance(authorization, dict):
+        return []  # Shape errors belong to the authorization validator.
+    action = authorization.get("authorized_action")
+    if not isinstance(action, str) or action not in {"stop", "mission_review", "anti_spiral_audit"}:
+        return []
+    narrowing = {
+        "transition_task": {"blocked", "paused", "pruned", "abandoned", "superseded"},
+        "set_mission_status": {"blocked", "requires_human", "budget_exhausted", "abandoned", "superseded"},
+    }
+    errors: list[str] = []
+    if decision.get("recommendation") in {"continue", "switch", "add"}:
+        errors.append(
+            f"continuation consequence: {action} cannot authorize recommendation "
+            f"{decision['recommendation']}"
+        )
+    mutations = decision.get("proposed_mutations")
+    if not isinstance(mutations, list):
+        return errors  # The shared shape check reports this separately.
+    for index, mutation in enumerate(mutations):
+        if not isinstance(mutation, dict):
+            errors.append(f"continuation consequence: mutation {index} must be an object")
+            continue
+        mutation_type, status = mutation.get("type"), mutation.get("status")
+        allowed = narrowing.get(mutation_type, set()) if isinstance(mutation_type, str) else set()
+        if not isinstance(status, str) or status not in allowed:
+            errors.append(
+                f"continuation consequence: {action} permits only narrowing mutations; "
+                f"mutation {index} requests {mutation.get('type')} / {mutation.get('status')}"
+            )
+    return errors
+
+
 def _validate_hook_output_messages(
     decision: Any,
     active_shared_risks: list[dict[str, Any]] | None = None,
@@ -6200,6 +6235,7 @@ def _validate_hook_output_messages(
         errors.extend(_validate_path_assessment(decision))
         errors.extend(_validate_risk_assessment(decision, active_shared_risks))
         errors.extend(_validate_continuation_authorization(decision))
+        errors.extend(_validate_decision_consequences(decision))
     return errors
 
 

--- a/skills/tplan/scripts/tplan_runtime.py
+++ b/skills/tplan/scripts/tplan_runtime.py
@@ -3294,6 +3294,46 @@ def _validate_trace_evidence_references(
     ]
 
 
+def _mission_completion_findings(
+    mission: dict[str, Any], events: list[dict[str, Any]]
+) -> list[str]:
+    """Check mechanical closure eligibility against one supplied evidence snapshot."""
+    errors: list[str] = []
+    incomplete = sorted(
+        str(task["id"]) for task in mission["tasks"]
+        if task.get("role") == "success-critical" and task.get("status") != "completed"
+    )
+    if incomplete:
+        errors.append("Mission completion requires completed success-critical nodes: " + ", ".join(incomplete))
+    counts = Counter(
+        event.get("id") for event in events
+        if isinstance(event, dict) and isinstance(event.get("id"), str)
+    )
+    latest: dict[str, str] = {}
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        kind = event.get("event_type")
+        if not isinstance(kind, str) or kind not in {"acceptance", "acceptance_passed", "acceptance_failed"}:
+            continue
+        if validate_evidence_event(mission, event, compatibility=True, internal=True):
+            continue
+        if counts[event["id"]] != 1:
+            continue  # Ambiguous historical IDs cannot provide a qualified observation.
+        for acceptance_id in event["payload"]["acceptance_ids"]:
+            latest[acceptance_id] = kind
+    missing = sorted(
+        acceptance_id for acceptance_id in acceptance_ids(mission)
+        if latest.get(acceptance_id) not in {"acceptance", "acceptance_passed"}
+    )
+    if missing:
+        errors.append(
+            "Mission completion requires positive qualified acceptance: "
+            + ", ".join(f"{item} ({latest.get(item, 'missing')})" for item in missing)
+        )
+    return errors
+
+
 def prepare_event(mission_dir: Path, event: dict[str, Any]) -> dict[str, Any]:
     event = dict(event)
     event.setdefault("id", _next_event_id(mission_dir))
@@ -4028,6 +4068,10 @@ def _commit_mission_state_unlocked(
     reference_errors = _validate_trace_evidence_references(records, evidence_snapshot)
     if reference_errors:
         raise TplanError("; ".join(reference_errors))
+    if before["mission"]["status"] != "completed" and after["mission"]["status"] == "completed":
+        completion_errors = _mission_completion_findings(after, evidence_snapshot)
+        if completion_errors:
+            raise TplanError("; ".join(completion_errors))
 
     paths = mission_paths(mission_dir)
     previous_trace = paths["trace"].read_text(encoding="utf-8") if paths["trace"].exists() else ""

--- a/tests/tplan/test_authority_integrity.py
+++ b/tests/tplan/test_authority_integrity.py
@@ -81,6 +81,54 @@ class AuthorityTestCase(unittest.TestCase):
         self.assertEqual(snapshot(self.mission), before)
 
 
+def added_node(node_id="T3", *, status="pending", parent=None):
+    value = {"id": node_id, "title": node_id, "status": status, "role": "supporting"}
+    if parent is None:
+        value.update(kind="task", mission_contribution="Supports existing work.", acceptance_evidence=[])
+    else:
+        value.update(kind="subtask", parent_id=parent,
+                     parent_contribution="Supports the selected parent.",
+                     parent_acceptance="Parent receives the result.", mission_trace="via parent")
+    return value
+
+
+class ActivePathAtomicityTests(AuthorityTestCase):
+    def test_create_and_activate_updates_cursor_and_events_in_one_commit(self):
+        runtime.transition_task_status(self.mission, "T1", "active")
+        for node in (added_node("T3", status="active"), added_node("T3.1", status="active", parent="T3")):
+            with self.subTest(node=node["id"]):
+                runtime.add_task_node(self.mission, node)
+                state = runtime.read_mission(self.mission)
+                self.assertEqual(state["active_task_id"], node["id"])
+                records = runtime.read_execution_trace(self.mission)
+                added = next(r for r in records if r["event_type"] == "node_added" and r["task_id"] == node["id"])
+                selected = next(r for r in records if r["event_type"] == "active_node_changed" and r["task_id"] == node["id"])
+                self.assertEqual(added["commit_id"], selected["commit_id"])
+                self.assertEqual(added["timestamp"], selected["timestamp"])
+        self.assertEqual(runtime.find_task(state, "T3")["status"], "active")
+
+    def test_pending_creation_preserves_selection_and_blocked_recovery_cursor(self):
+        runtime.transition_task_status(self.mission, "T1", "active")
+        runtime.add_task_node(self.mission, added_node())
+        self.assertEqual(runtime.read_mission(self.mission)["active_task_id"], "T1")
+        runtime.record_stop_report(self.mission, "T1", "Needs a decision.", {
+            "current_goal": "Finish the Mission.", "attempts": ["Inspected evidence."],
+            "blocking_issue": "Missing authority.", "why_cannot_continue_safely": "User decision is required.",
+            "need_from_human": "Confirm the boundary.", "resume_condition": "Decision received.",
+        })
+        runtime.add_task_node(self.mission, added_node("T4"))
+        state = runtime.read_mission(self.mission)
+        self.assertEqual(state["active_task_id"], "T1")
+        self.assertEqual(runtime.find_task(state, "T1")["status"], "blocked")
+
+    def test_failed_create_and_activate_has_no_orphan_or_partial_cursor(self):
+        before = snapshot(self.mission)
+        with mock.patch.object(runtime, "write_json", side_effect=OSError("journal unavailable")):
+            with self.assertRaisesRegex(OSError, "journal unavailable"):
+                runtime.add_task_node(self.mission, added_node(status="active"))
+        self.assertEqual(snapshot(self.mission), before)
+
+
 class EvidenceReferenceIntegrityTests(AuthorityTestCase):
     def test_missing_path_and_cross_mission_ids_are_rejected_atomically(self):
         other = create_mission(self.root / "other")

--- a/tests/tplan/test_authority_integrity.py
+++ b/tests/tplan/test_authority_integrity.py
@@ -203,6 +203,149 @@ class ActivePathAtomicityTests(AuthorityTestCase):
         self.assertEqual(snapshot(self.mission), before)
 
 
+def complete_tasks(root):
+    for task_id in ("T1", "T2"):
+        runtime.transition_task_status(root, task_id, "completed")
+
+
+def pass_requirements(root):
+    for task_id, acceptance_id in (("T1", "A1"), ("T2", "A2")):
+        event(root, event_id="E-" + acceptance_id, event_type="acceptance_passed",
+              task_id=task_id, payload={"acceptance_ids": [acceptance_id]})
+
+
+def close_decision():
+    return decision(recommendation="close", mutations=[{"type": "set_mission_status", "status": "completed"}])
+
+
+class MissionCompletionIntegrityTests(AuthorityTestCase):
+    def test_every_success_critical_status_other_than_completed_blocks_closure(self):
+        for status in sorted(runtime.TASK_STATUSES - {"completed"}):
+            with self.subTest(status=status):
+                self.mission = create_mission(self.root / f"critical-{status}")
+                pass_requirements(self.mission)
+                before = runtime.read_mission(self.mission)
+                after = copy.deepcopy(before)
+                for task in after["tasks"]:
+                    task["status"] = "completed"
+                after["tasks"][0]["status"] = status
+                after["mission"]["status"] = "completed"
+                self.assert_rejected_without_writes(
+                    lambda: runtime.commit_mission_state(
+                        self.mission, before, after, source={"kind": "test", "name": "closure"}),
+                    "Mission completion.*success-critical")
+
+    def test_missing_acceptance_blocks_close_without_blocking_task_completion(self):
+        complete_tasks(self.mission)
+        self.assert_rejected_without_writes(
+            lambda: runtime.apply_decision(self.mission, close_decision()), "Mission completion.*acceptance")
+        self.assertTrue(all(t["status"] == "completed" for t in runtime.read_mission(self.mission)["tasks"]))
+
+    def test_stream_order_controls_latest_qualified_acceptance(self):
+        cases = [
+            (("acceptance_passed", "acceptance_failed"), False),
+            (("acceptance_failed", "acceptance_passed"), True),
+            (("acceptance",), True),
+        ]
+        for i, (history, allowed) in enumerate(cases):
+            with self.subTest(history=history):
+                self.mission = create_mission(self.root / f"history-{i}")
+                complete_tasks(self.mission)
+                event(self.mission, event_id="E-A2", task_id="T2", event_type="acceptance_passed",
+                      payload={"acceptance_ids": ["A2"]})
+                for index, kind in enumerate(history):
+                    runtime.append_event(self.mission, {
+                        "id": f"E-{index}", "timestamp": f"2026-09-0{5-index}T12:00:00Z",
+                        "event_type": kind, "task_id": "T1", "summary": "Observed acceptance.",
+                        "payload": {"acceptance_ids": ["A1"]},
+                    })
+                if allowed:
+                    self.assertEqual(runtime.apply_decision(self.mission, close_decision()), "applied_decision")
+                    self.assertEqual(runtime.read_mission(self.mission)["mission"]["status"], "completed")
+                else:
+                    self.assert_rejected_without_writes(
+                        lambda: runtime.apply_decision(self.mission, close_decision()), "Mission completion.*acceptance")
+
+    def test_wrong_scope_incomplete_and_duplicate_acceptance_cannot_qualify(self):
+        for variant in ("wrong_scope", "incomplete_legacy", "duplicate", "key_finding"):
+            with self.subTest(variant=variant):
+                self.mission = create_mission(self.root / variant)
+                complete_tasks(self.mission)
+                event(self.mission, event_id="E-A2", task_id="T2", event_type="acceptance_passed",
+                      payload={"acceptance_ids": ["A2"]})
+                raw = {"id": "E-A1", "timestamp": "2026-09-05T12:00:00Z", "summary": "Historical observation.",
+                       "event_type": "acceptance_passed", "task_id": "T1", "payload": {"acceptance_ids": ["A1"]}}
+                if variant == "wrong_scope":
+                    raw["task_id"] = "T2"
+                elif variant == "incomplete_legacy":
+                    raw.update(event_type="acceptance", payload={})
+                elif variant == "key_finding":
+                    raw["event_type"] = "key_finding"
+                path = runtime.mission_paths(self.mission)["evidence"]
+                with path.open("a", encoding="utf-8") as stream:
+                    stream.write((json.dumps(raw) + "\n") * (2 if variant == "duplicate" else 1))
+                self.assert_rejected_without_writes(
+                    lambda: runtime.apply_decision(self.mission, close_decision()), "Mission completion.*acceptance")
+
+    def test_same_transaction_can_complete_tasks_and_supply_acceptance(self):
+        before = runtime.read_mission(self.mission)
+        after = copy.deepcopy(before)
+        prepared = []
+        for task_id, acceptance_id in (("T1", "A1"), ("T2", "A2")):
+            runtime.set_task_status(after, task_id, "completed")
+            prepared.append(runtime.prepare_event(self.mission, {
+                "id": "E-" + acceptance_id, "event_type": "acceptance_passed", "task_id": task_id,
+                "summary": "Reviewed acceptance.", "payload": {"acceptance_ids": [acceptance_id]},
+            }))
+        after["mission"]["status"] = "completed"
+        runtime.commit_mission_state(
+            self.mission, before, after, source={"kind": "test", "name": "atomic_closure"},
+            refs={"evidence_ids": [e["id"] for e in prepared]}, prepared_evidence_events=prepared)
+        self.assertEqual(runtime.read_mission(self.mission)["mission"]["status"], "completed")
+
+    def test_adverse_evidence_arriving_after_candidate_build_blocks_close(self):
+        complete_tasks(self.mission)
+        pass_requirements(self.mission)
+        before = runtime.read_mission(self.mission)
+        after = copy.deepcopy(before)
+        after["mission"]["status"] = "completed"
+        event(self.mission, event_id="E-late-fail", event_type="acceptance_failed", payload={"acceptance_ids": ["A1"]})
+        self.assert_rejected_without_writes(
+            lambda: runtime.commit_mission_state(self.mission, before, after, source={"kind": "test", "name": "late"}),
+            "Mission completion.*acceptance")
+
+    def test_unfinished_supporting_work_is_not_a_mission_approval_gate(self):
+        runtime.add_task_node(self.mission, added_node())
+        complete_tasks(self.mission)
+        pass_requirements(self.mission)
+        runtime.apply_decision(self.mission, close_decision())
+        state = runtime.read_mission(self.mission)
+        self.assertEqual(state["mission"]["status"], "completed")
+        self.assertEqual(runtime.find_task(state, "T3")["status"], "pending")
+
+    def test_guarded_closure_uses_the_same_completion_boundary(self):
+        apply = guarded_apply(self.mission, close_decision())
+        self.assert_rejected_without_writes(apply, "Mission completion")
+        self.assertIsNotNone(runtime.read_interaction_guard(self.mission))
+
+    def test_advisory_closure_remains_a_recommendation(self):
+        proposed = close_decision()
+        proposed["requires_human"] = True
+        before = runtime.mission_paths(self.mission)["mission"].read_bytes()
+        self.assertEqual(runtime.apply_decision(self.mission, proposed), "recorded_recommendation")
+        self.assertEqual(runtime.mission_paths(self.mission)["mission"].read_bytes(), before)
+
+    def test_historical_completed_state_remains_readable_without_retroactive_acceptance(self):
+        path = runtime.mission_paths(self.mission)["mission"]
+        state = runtime.read_mission(self.mission)
+        state["mission"]["status"] = "completed"
+        path.write_text(json.dumps(state), encoding="utf-8")
+        historic = path.read_bytes()
+        self.assertEqual(runtime.read_mission(self.mission)["mission"]["status"], "completed")
+        event(self.mission, event_id="E-history-note")
+        self.assertEqual(path.read_bytes(), historic)
+
+
 class EvidenceReferenceIntegrityTests(AuthorityTestCase):
     def test_missing_path_and_cross_mission_ids_are_rejected_atomically(self):
         other = create_mission(self.root / "other")

--- a/tests/tplan/test_authority_integrity.py
+++ b/tests/tplan/test_authority_integrity.py
@@ -2,10 +2,13 @@
 
 import copy
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parents[2] / "skills" / "tplan" / "scripts"
@@ -344,6 +347,122 @@ class MissionCompletionIntegrityTests(AuthorityTestCase):
         self.assertEqual(runtime.read_mission(self.mission)["mission"]["status"], "completed")
         event(self.mission, event_id="E-history-note")
         self.assertEqual(path.read_bytes(), historic)
+
+
+class AuthorityBoundaryReviewTests(AuthorityTestCase):
+    def test_compatibility_writer_cannot_bypass_completion_gate(self):
+        state = runtime.read_mission(self.mission)
+        state["mission"]["status"] = "completed"
+        self.assert_rejected_without_writes(
+            lambda: runtime.write_mission(self.mission, state), "Mission completion")
+
+    def test_standalone_trace_append_resolves_typed_evidence_ids(self):
+        state = runtime.read_mission(self.mission)
+        record = runtime._new_trace_record(
+            state, "active_node_changed", task_id="T1",
+            payload={"from_task_id": None, "to_task_id": "T1"},
+            refs={"evidence_ids": ["E-missing"]},
+            source={"kind": "test", "name": "standalone"}, commit_id="C-standalone",
+        )
+        self.assert_rejected_without_writes(
+            lambda: runtime.append_execution_trace_record(self.mission, record), "evidence.*reference")
+
+    def test_compatible_existing_writer_produces_canonical_lifecycle(self):
+        complete_tasks(self.mission)
+        pass_requirements(self.mission)
+        state = runtime.read_mission(self.mission)
+        state["mission"]["status"] = "completed"
+        runtime.write_mission(self.mission, state)
+        records = runtime.read_execution_trace(self.mission)
+        self.assertTrue(any(r["event_type"] == "mission_status_changed"
+                            and r["payload"]["to_status"] == "completed" for r in records))
+
+    def test_historical_reference_and_closure_warnings_preserve_files(self):
+        runtime.transition_task_status(self.mission, "T1", "completed")
+        paths = runtime.mission_paths(self.mission)
+        records = runtime.read_execution_trace(self.mission)
+        records[-1]["refs"] = {"evidence_ids": ["E-historical-missing"]}
+        paths["trace"].write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+        state = runtime.read_mission(self.mission)
+        state["mission"]["status"] = "completed"
+        paths["mission"].write_text(json.dumps(state), encoding="utf-8")
+        before = snapshot(self.mission)
+        result = subprocess.run([sys.executable, str(SCRIPTS / "check_mission.py"), str(self.mission)],
+                                text=True, capture_output=True)
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("integrity_warning: evidence reference", result.stdout)
+        self.assertIn("integrity_warning: Mission completion", result.stdout)
+        self.assertEqual(snapshot(self.mission), before)
+
+    def test_guarded_valid_closure_commits_and_releases_guard(self):
+        complete_tasks(self.mission)
+        pass_requirements(self.mission)
+        apply = guarded_apply(self.mission, close_decision())
+        self.assertEqual(apply()["disposition"], "apply_authorized_change")
+        self.assertIsNone(runtime.read_interaction_guard(self.mission))
+        self.assertEqual(runtime.read_mission(self.mission)["mission"]["status"], "completed")
+
+    def test_concurrent_evidence_append_serializes_after_locked_closure(self):
+        complete_tasks(self.mission)
+        pass_requirements(self.mission)
+        entered, release, append_started, append_done = Event(), Event(), Event(), Event()
+        journal = runtime.mission_paths(self.mission)["transaction"]
+        real_write = runtime.write_json
+
+        def pause_journal(path, *args, **kwargs):
+            if path == journal:
+                entered.set()
+                if not release.wait(5):
+                    raise AssertionError("test release missing")
+            return real_write(path, *args, **kwargs)
+
+        def append_failure():
+            append_started.set()
+            try:
+                return event(self.mission, event_id="E-after-close", event_type="acceptance_failed",
+                             payload={"acceptance_ids": ["A1"]})
+            finally:
+                append_done.set()
+
+        with mock.patch.object(runtime, "write_json", side_effect=pause_journal):
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                closed = pool.submit(runtime.apply_decision, self.mission, close_decision())
+                try:
+                    self.assertTrue(entered.wait(5))
+                    appended = pool.submit(append_failure)
+                    self.assertTrue(append_started.wait(5))
+                    self.assertFalse(append_done.wait(0.1))
+                finally:
+                    release.set()
+                self.assertEqual(closed.result(timeout=5), "applied_decision")
+                self.assertEqual(appended.result(timeout=5)["id"], "E-after-close")
+        events = runtime.read_events(self.mission)
+        self.assertEqual(events[-2]["event_type"], "decision_applied")
+        self.assertEqual(events[-1]["id"], "E-after-close")
+        self.assertTrue(runtime._mission_completion_findings(runtime.read_mission(self.mission), events))
+
+    def test_interrupted_qualified_closure_recovers_once_from_prepared_contents(self):
+        complete_tasks(self.mission)
+        pass_requirements(self.mission)
+        trace_path = runtime.mission_paths(self.mission)["trace"]
+        real_write = runtime.write_text_atomic
+
+        def interrupt(path, *args, **kwargs):
+            if path == trace_path:
+                raise OSError("interrupted after journal")
+            return real_write(path, *args, **kwargs)
+
+        with mock.patch.object(runtime, "write_text_atomic", side_effect=interrupt):
+            with self.assertRaisesRegex(OSError, "interrupted after journal"):
+                runtime.apply_decision(self.mission, close_decision())
+        self.assertTrue(runtime.mission_paths(self.mission)["transaction"].exists())
+        self.assertEqual(runtime.read_mission(self.mission)["mission"]["status"], "completed")
+        stable = snapshot(self.mission)
+        runtime.read_mission(self.mission)
+        self.assertEqual(snapshot(self.mission), stable)
+        events = runtime.read_events(self.mission)
+        self.assertEqual(sum(e["event_type"] == "decision_applied" for e in events), 1)
+        self.assertFalse(runtime.mission_paths(self.mission)["transaction"].exists())
 
 
 class EvidenceReferenceIntegrityTests(AuthorityTestCase):

--- a/tests/tplan/test_authority_integrity.py
+++ b/tests/tplan/test_authority_integrity.py
@@ -92,6 +92,80 @@ def added_node(node_id="T3", *, status="pending", parent=None):
     return value
 
 
+def guarded_apply(root, proposed):
+    """Prepare a genuinely bound receipt; return the final application operation."""
+    guard = runtime.begin_interaction_guard(root, platform="test-host", message_ref="M1")
+    runtime.resolve_interaction_guard(
+        root, guard_id=guard["guard_id"], expected_revision=guard["revision"], message_refs=["M1"],
+        disposition="await_clarification", proposal_id="P1", proposal_decision=proposed,
+    )
+    confirmed = runtime.begin_interaction_guard(root, platform="test-host", message_ref="M2")
+    receipt = runtime.issue_authority_receipt(
+        root, guard_id=confirmed["guard_id"], guard_revision=confirmed["revision"],
+        proposal_id="P1", decision=proposed, confirmation_ref="M2", secret="test-only-secret",
+    )
+    return lambda: runtime.resolve_interaction_guard(
+        root, guard_id=confirmed["guard_id"], expected_revision=confirmed["revision"],
+        message_refs=["M2"], disposition="apply_authorized_change", decision=proposed,
+        authority_receipt=receipt, receipt_secret="test-only-secret",
+    )
+
+
+class ContinuationConsequenceTests(AuthorityTestCase):
+    def test_stop_and_review_ceiling_reject_execution_even_with_changed_recommendation(self):
+        mutations = [
+            {"type": "set_active_task", "task_id": "T1"},
+            {"type": "transition_task", "task_id": "T1", "status": "active"},
+            {"type": "transition_task", "task_id": "T1", "status": "pending"},
+            {"type": "transition_task", "task_id": "T1", "status": "completed"},
+            {"type": "set_mission_status", "status": "active"},
+            {"type": "set_mission_status", "status": "completed"},
+        ]
+        for action in ("stop", "mission_review", "anti_spiral_audit"):
+            for mutation in mutations:
+                with self.subTest(action=action, mutation=mutation):
+                    proposed = decision(recommendation="escalate", action=action, mutations=[mutation])
+                    self.assertTrue(runtime.validate_hook_output(proposed))
+                    self.assert_rejected_without_writes(
+                        lambda: runtime.apply_decision(self.mission, proposed), "continuation.*consequence")
+
+    def test_stop_cannot_authorize_continue_by_omitting_mutations(self):
+        for recommendation in ("continue", "switch", "add"):
+            with self.subTest(recommendation=recommendation):
+                proposed = decision(recommendation=recommendation, action="stop")
+                self.assert_rejected_without_writes(
+                    lambda: runtime.apply_decision(self.mission, proposed), "continuation.*consequence")
+
+    def test_consistent_continue_and_narrowing_dispositions_remain_usable(self):
+        for action in ("continue_same_path", "targeted_fix", "batch_details"):
+            with self.subTest(action=action):
+                proposed = decision(recommendation="continue", action=action)
+                proposed["path_assessment"]["marginal_roi"] = "weak"
+                proposed["continuation_authorization"]["evidence_shape_lint"] = "fail"
+                proposed["continuation_authorization"]["expected_evidence_delta"] = "unclear"
+                self.assertEqual(runtime.apply_decision(self.mission, proposed), "applied_decision")
+        proposed = decision(recommendation="escalate", action="stop", mutations=[
+            {"type": "set_mission_status", "status": "requires_human"}])
+        self.assertEqual(runtime.apply_decision(self.mission, proposed), "applied_decision")
+        self.assertEqual(runtime.read_mission(self.mission)["mission"]["status"], "requires_human")
+
+    def test_consistent_review_is_recordable_without_execution(self):
+        for action in ("stop", "mission_review", "anti_spiral_audit"):
+            with self.subTest(action=action):
+                proposed = decision(recommendation="escalate", action=action)
+                proposed["requires_human"] = True
+                mission_before = runtime.mission_paths(self.mission)["mission"].read_bytes()
+                self.assertEqual(runtime.apply_decision(self.mission, proposed), "recorded_recommendation")
+                self.assertEqual(runtime.mission_paths(self.mission)["mission"].read_bytes(), mission_before)
+
+    def test_real_guard_receipt_cannot_override_stop_contradiction(self):
+        proposed = decision(recommendation="continue", action="stop", mutations=[
+            {"type": "set_active_task", "task_id": "T1"}])
+        apply = guarded_apply(self.mission, proposed)
+        self.assert_rejected_without_writes(apply, "continuation.*consequence")
+        self.assertIsNotNone(runtime.read_interaction_guard(self.mission))
+
+
 class ActivePathAtomicityTests(AuthorityTestCase):
     def test_create_and_activate_updates_cursor_and_events_in_one_commit(self):
         runtime.transition_task_status(self.mission, "T1", "active")

--- a/tests/tplan/test_authority_integrity.py
+++ b/tests/tplan/test_authority_integrity.py
@@ -1,0 +1,160 @@
+"""Cross-entry regressions for #196-#199; assertions cover effects, not field presence."""
+
+import copy
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "skills" / "tplan" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import tplan_runtime as runtime
+
+
+def snapshot(root):
+    return {str(p.relative_to(root)): p.read_bytes() for p in root.rglob("*") if p.is_file()}
+
+
+def create_mission(root, *, human_in_loop=0):
+    root.mkdir(parents=True)
+    mission = runtime.build_mission(
+        mission_id=root.name,
+        title="Authority integrity",
+        objective="Keep declared authority and committed consequences consistent.",
+        acceptance_evidence=[
+            {"id": "A1", "description": "First requirement is met."},
+            {"id": "A2", "description": "Second requirement is met."},
+        ],
+        human_in_loop=human_in_loop, risk_tolerance=50, resource_sufficiency=50,
+        tasks=[
+            {"id": task_id, "title": task_id, "role": "success-critical",
+             "mission_contribution": "Satisfies the declared requirement.",
+             "acceptance_evidence": [acceptance_id]}
+            for task_id, acceptance_id in (("T1", "A1"), ("T2", "A2"))
+        ],
+    )
+    runtime.write_mission(root, mission)
+    runtime.initialize_execution_trace(root, mission)
+    return root
+
+
+def event(root, *, event_id="E-valid", event_type="key_finding", task_id="T1", payload=None):
+    return runtime.append_event(root, {
+        "id": event_id, "event_type": event_type, "summary": "An observed result.",
+        "task_id": task_id, "payload": {} if payload is None else payload,
+    })
+
+
+def decision(*, recommendation="switch", mutations=None, action=None):
+    value = {
+        "recommendation": recommendation, "rationale": "Apply the reviewed disposition.",
+        "confidence": 80, "evidence_links": [], "requires_human": False,
+        "mission_alignment": "The requested state matches the declared Mission boundary.",
+        "path_assessment": {"marginal_roi": "positive", "path_role": "dominant_path",
+                            "evidence_delta": "new_evidence_expected"},
+        "proposed_mutations": [] if mutations is None else mutations,
+    }
+    if action is not None:
+        value["continuation_authorization"] = {
+            "trigger_reasons": ["manual_authorization"], "evidence_shape_lint": "pass",
+            "defect_classification": "none", "expected_evidence_delta": "new_evidence_expected",
+            "authorized_action": action,
+        }
+    return value
+
+
+class AuthorityTestCase(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.mission = create_mission(self.root / "mission")
+
+    def assert_rejected_without_writes(self, operation, pattern):
+        before = snapshot(self.mission)
+        with self.assertRaisesRegex(runtime.TplanError, pattern):
+            operation()
+        self.assertEqual(snapshot(self.mission), before)
+
+
+class EvidenceReferenceIntegrityTests(AuthorityTestCase):
+    def test_missing_path_and_cross_mission_ids_are_rejected_atomically(self):
+        other = create_mission(self.root / "other")
+        event(other, event_id="E-other")
+        artifact = self.mission / "result.txt"
+        artifact.write_text("real artifact", encoding="utf-8")
+        for ref in ("EPLACEHOLDER", str(artifact), "E-other"):
+            with self.subTest(ref=ref):
+                self.assert_rejected_without_writes(
+                    lambda: runtime.transition_task_status(
+                        self.mission, "T1", "completed", evidence_refs=[ref]),
+                    "evidence.*reference",
+                )
+
+    def test_existing_and_same_transaction_evidence_are_resolvable(self):
+        existing = event(self.mission)
+        runtime.transition_task_status(self.mission, "T1", "completed", evidence_refs=[existing["id"]])
+        before = runtime.read_mission(self.mission)
+        after = copy.deepcopy(before)
+        runtime.set_task_status(after, "T2", "active")
+        prepared = runtime.prepare_event(self.mission, {
+            "id": "E-prepared", "event_type": "key_finding", "summary": "Atomic evidence.",
+            "task_id": "T2", "payload": {},
+        })
+        runtime.commit_mission_state(
+            self.mission, before, after, source={"kind": "test", "name": "prepared"},
+            refs={"evidence_ids": [existing["id"], prepared["id"]]},
+            prepared_evidence_events=[prepared],
+        )
+        self.assertEqual(runtime.read_mission(self.mission)["active_task_id"], "T2")
+        self.assertEqual(sum(e["id"] == "E-prepared" for e in runtime.read_events(self.mission)), 1)
+        # Correctly typed artifact references need no fabricated evidence event.
+        runtime.transition_task_status(self.mission, "T2", "completed", artifact_refs=["result.txt"])
+
+    def test_ambiguous_historical_id_blocks_only_new_uses_of_that_id(self):
+        entry = event(self.mission)
+        path = runtime.mission_paths(self.mission)["evidence"]
+        with path.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(entry) + "\n")
+        history = path.read_bytes()
+        self.assert_rejected_without_writes(
+            lambda: runtime.transition_task_status(self.mission, "T1", "completed", evidence_refs=[entry["id"]]),
+            "evidence.*reference",
+        )
+        unique = event(self.mission, event_id="E-unique")
+        runtime.transition_task_status(self.mission, "T2", "active", evidence_refs=[unique["id"]])
+        self.assertTrue(path.read_bytes().startswith(history))
+        self.assertEqual(runtime.read_mission(self.mission)["active_task_id"], "T2")
+
+    def test_reference_rejection_discards_prepared_evidence_before_journal(self):
+        before = runtime.read_mission(self.mission)
+        after = copy.deepcopy(before)
+        runtime.set_task_status(after, "T1", "active")
+        prepared = runtime.prepare_event(self.mission, {
+            "id": "E-uncommitted", "event_type": "key_finding", "summary": "Candidate only.",
+            "task_id": "T1", "payload": {},
+        })
+        self.assert_rejected_without_writes(
+            lambda: runtime.commit_mission_state(
+                self.mission, before, after, source={"kind": "test", "name": "invalid_ref"},
+                refs={"evidence_ids": [prepared["id"], "E-missing"]}, prepared_evidence_events=[prepared]),
+            "evidence.*reference",
+        )
+
+    def test_extra_lifecycle_records_cannot_bypass_reference_resolution(self):
+        before = runtime.read_mission(self.mission)
+        extra = runtime._new_trace_record(
+            before, "active_node_changed", task_id="T1",
+            payload={"from_task_id": None, "to_task_id": "T1"},
+            refs={"evidence_ids": ["E-missing"]},
+            source={"kind": "test", "name": "extra"}, commit_id="C-extra",
+        )
+        with runtime.execution_trace_lock(self.mission):
+            self.assert_rejected_without_writes(
+                lambda: runtime._commit_mission_state_unlocked(
+                    self.mission, before, before, source={"kind": "test", "name": "extra"},
+                    extra_trace_records=[extra]), "evidence.*reference")

--- a/tests/tplan/test_execution_cost_tree.py
+++ b/tests/tplan/test_execution_cost_tree.py
@@ -17,6 +17,7 @@ from observe_model_call import ModelCallObserver
 from execution_cost_tree import _counted_tokens, _duration_hotspots, _span_cost, _usage_owner_event_ids
 from tplan_runtime import (
     TplanError,
+    append_event,
     begin_interaction_guard,
     record_execution_span,
     start_execution_span,
@@ -112,6 +113,12 @@ def create_tree_mission(tmp):
 
 
 def complete_mission_status(tmp, mission_dir):
+    # This is a lifecycle-rendering fixture, with explicitly supplied acceptance.
+    append_event(mission_dir, {
+        "event_type": "acceptance_passed", "task_id": "T1",
+        "summary": "Fixture supplies the completed tree/report acceptance observation.",
+        "payload": {"acceptance_ids": ["A1"]},
+    })
     decision = Path(tmp) / "complete-mission-decision.json"
     decision.write_text(
         json.dumps(
@@ -486,6 +493,11 @@ class ExecutionCostTreeTests(unittest.TestCase):
             self.assertEqual(added.returncode, 0, added.stderr)
             active = run_script("transition_task.py", str(mission_dir), "--task-id", "E1", "--status", "active")
             self.assertEqual(active.returncode, 0, active.stderr)
+            append_event(mission_dir, {
+                "id": "E-acceptance", "event_type": "acceptance_passed", "task_id": "E1",
+                "summary": "Fixture supplies the route artifact acceptance observation.",
+                "payload": {"acceptance_ids": ["A1"]},
+            })
             completed = run_script(
                 "transition_task.py",
                 str(mission_dir),

--- a/tests/tplan/test_init_lite.py
+++ b/tests/tplan/test_init_lite.py
@@ -206,6 +206,12 @@ class InitLiteTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
+            accepted = run_script(
+                "record_evidence.py", str(mission_dir), "--event-type", "acceptance_passed",
+                "--task-id", "T1", "--summary", "Fixture confirms the recovery-state acceptance.",
+                "--payload-json", json.dumps({"acceptance_ids": ["A1"]}),
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
             closed = run_script("apply_decision.py", str(mission_dir), "--decision", str(decision))
 
             self.assertEqual(closed.returncode, 0, closed.stderr)


### PR DESCRIPTION
## Scope
Fixes #196, fixes #197, fixes #199, fixes #198.

Implements the frozen authority-contract audit in separate commits. Reference resolution and Mission-completion eligibility share the existing locked transaction. Dynamic activation reuses the current status primitive. One decision-consequence validator covers ordinary and Guard-authorized application.

## Implementation review
Same-assistant review after self-tests identified two alternate-writer gaps: existing-state write_mission and standalone trace append. Both now reuse the canonical checks. Historical diagnostics preserve files. No independent-model certification is claimed.

## Final verification
Product/test commit: 45c0ac0b1cdc80465deeb2accba5ad80bf919535.
Fresh worktree, CPython 3.10.12: 1084 tests run, 1079 passed, 5 existing optional skips. Thirty new authority regression methods pass. Lifecycle registry 79/79 valid. Five release layouts built, changed scripts byte-match source, five isolated import/fingerprint/contract probes pass. Original bounded case remains 10/10 hash-matched; its four current-runtime contradictions now have correct outcomes.

Full review: docs/internal/audits/2026-09-05-tplan-authority-contract-implementation-review.md

## Boundaries
No #200 implementation, SRA method change, host hook, scheduler, original incident rewrite, version bump, tag or release. No Codex App/Sol High 16-hour replay or causal ROI claim. This PR is left open for merge review.