### PR TITLE
chore(release): prepare v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Unreleased
 
+## v1.10.1
+
+发布 tag：`v1.10.1`
+
+[发布说明](docs/releases/v1.10.1.md)
+
+发布日期：2026-09-05
+
+### TPlan Authority Integrity Bugfix
+
+- 修复新 lifecycle `refs.evidence_ids` 只校验字符串形状、未在同一 Mission 事务边界解析真实证据的问题；缺失、跨 Mission、歧义重复和误填文件路径的 evidence ID 现在会在写入前失败，合法既有证据和同事务新增证据继续可用。
+- 修复动态 `add_node --status active` 可产生 active 节点但 `active_task_id` 为空的问题；创建并激活现在复用 canonical activation，在一个逻辑事务中同步节点、游标和 lifecycle consequence。
+- 修复 `continuation_authorization.authorized_action` 与实际 mutation 可机械矛盾的问题；`stop`、`mission_review`、`anti_spiral_audit` 不再能静默授权继续执行，普通 apply 与 Interaction Guard 授权路径共享同一 consequence validator。
+- 修复 Mission 可在 success-critical 工作未完成、验收缺失或最新合格观察为失败时进入 `completed` 的问题；新完成事务必须满足所有 success-critical 节点完成且每个 Mission acceptance ID 的最新 qualified observation 为正。
+- 评审中同时关闭旧 `write_mission()` 兼容写入和独立 trace append 对上述新约束的旁路；历史记录保持可读，不回写伪造证据或重新解释既有 pending transaction。
+
+### 补充发布包：1.10.1 ROI Beta（GPT/Sol）
+
+- Stable release 按默认规则同步提供 `v1.10.1-roi-beta` supplemental experimental asset。
+- Beta 从精确 `v1.10.1` Stable shared core 组装并继承本版 TPlan authority-integrity 修复；ROI runtime delta 不新增能力，继续限定为 SRA-compatible ROI Thin Core、历史 ROI.2 3L5S Anti-Spiral correction、独立 identity / namespace 与 diagnostic 坐标。
+- 本 patch 不新增 Beta-specific 自然唤醒率、相对胜率、真实任务收益或 Token ROI 声明。
+
+### 兼容性、验证与发布资产
+
+- 这是 `v1.10.0` 的向后兼容 Bugfix patch；SRA Proportionate Allocation 与 v0.4 合同保持不变，TPlan runtime generation 继续为 `1.5.4` / `mindthus-v1.5.4`。
+- 修复分支 fresh-worktree 全套回归、Test Lifecycle、五布局 release pack 与 GitHub CI 已通过；补丁发布只追加版本面与打包校验，不重复另开资格验证。
+- `v1.10.1` GitHub Release 提供 `mindthus-plugins-1.10.1.tar.gz`、`mindthus-skills-1.10.1.tar.gz`、`mindthus-beta-1.10.1-roi-beta.tar.gz` 与覆盖三份归档的 `SHA256SUMS`。
+
+### Claim ceiling
+
+- 四项修复关闭的是确定性 TPlan authority-integrity 缺陷，不等于已经通过真实 Codex App / Sol High 重跑证明类似约16小时执行过载不会再发生。
+- 跨工作区续投/资源 tranche、Codex App Hook 激活可靠性和宿主原生 mutation prevention 仍由 #200、#146、#140 等后续议题负责；本 patch 不扩张这些边界。
+
 ## v1.10.0
 
 发布 tag：`v1.10.0`

--- a/README.md
+++ b/README.md
@@ -116,23 +116,18 @@ Host 根据自然语言自行发现并唤起 Mindthus 属于 **best-effort** 能
 
 **发布默认规则**：Stable release 默认同步提供同版本 ROI Beta supplemental asset；只有该版本在发布前明确声明例外时才不发布 ROI Beta。
 
-当前已发布 Stable 是 `v1.10.0`。这是 **SRA / Scarce Resource Allocation / 稀缺资源优先分配 Proportionate Allocation** minor release：
-在 `v1.9.x` 已稳定的资源、依赖、授权和 Repair 合同上，让 SRA 回到“先保护目标成立所必需的投入，
-再把下一份资源分给当前风险调整后边际价值最高的用途”，并让判断成本与错误分配后果成比例。
-本版增加 v0.4 输入合同、Lite / Full 与 Single / Dual 校准解耦、输入草稿、checked Decision Card、
-完成条件引用和显式 rerank lineage；旧 v0.3 输入/Run 继续保留兼容边界。TPlan 的 Mission、Pulse、
-继续授权和 runtime generation 仍保持原 owner 与 `1.5.4` 代际。
+当前已发布 Stable 是 `v1.10.1`。这是 `v1.10.0` 的 **TPlan Authority Integrity Bugfix patch**：
+不新增方法、route、判断 owner 或 TPlan runtime generation，而是修复真实 Codex App / Sol High 长任务事故复盘中确认的四类确定性合同缺口：证据引用必须真实解析、动态节点创建与激活游标原子一致、续行授权必须约束实际 mutation、Mission 只有在 success-critical 工作完成且当前验收观察为正时才能进入 completed。
 
-`v1.10.0` Release 同步提供 Stable plugins、Stable skills 与 ROI Beta supplemental
-experimental asset。ROI Beta 从精确 `v1.10.0` Stable shared core 组装，继承完整 SRA 能力；
-其 runtime delta 继续限定为已资格验证的 SRA-compatible ROI Thin Core、历史 ROI.2 3L5S
-Anti-Spiral correction、Beta identity / namespace 与 diagnostic 坐标。Beta 不取代 Stable，也不自动迁移。
+SRA / Scarce Resource Allocation 的 Proportionate Allocation、v0.4 输入合同、Lite / Full 与 Single / Dual 校准、checked Decision Card、completion criterion reference 与 rerank lineage 均保持 `v1.10.0` 行为；TPlan runtime generation 继续保持 `1.5.4` 代际。此次 patch 关闭的是确定性 authority-integrity 缺陷，不声称 Codex App / Sol High 下类似 16 小时执行过载已经被端到端证明消失。
 
-- Codex App / Codex CLI / Claude Code 支持插件：下载 `mindthus-plugins-1.10.0.tar.gz`。
-- 不使用插件、需要 OpenCode、或只想复制 skills 目录：下载 `mindthus-skills-1.10.0.tar.gz`。
+`v1.10.1` Release 同步提供 Stable plugins、Stable skills 与 ROI Beta supplemental experimental asset。ROI Beta 从精确 `v1.10.1` Stable shared core 组装，继承本版 TPlan 修复；其 runtime delta 继续限定为已资格验证的 SRA-compatible ROI Thin Core、历史 ROI.2 3L5S Anti-Spiral correction、Beta identity / namespace 与 diagnostic 坐标。Beta 不取代 Stable，也不自动迁移。
+
+- Codex App / Codex CLI / Claude Code 支持插件：下载 `mindthus-plugins-1.10.1.tar.gz`。
+- 不使用插件、需要 OpenCode、或只想复制 skills 目录：下载 `mindthus-skills-1.10.1.tar.gz`。
 - 只在高能力 Codex / GPT-Sol 上复查低开销唤起实验：下载
-  `mindthus-beta-1.10.0-roi-beta.tar.gz`；它使用独立的 Codex plugin / marketplace 包与
-  `mindthus-beta` 命名空间，不是通用 skills-pack，也不是 v1.10.0 Stable 的替代品。
+  `mindthus-beta-1.10.1-roi-beta.tar.gz`；它使用独立的 Codex plugin / marketplace 包与
+  `mindthus-beta` 命名空间，不是通用 skills-pack，也不是 v1.10.1 Stable 的替代品。
 
 不要在同一个 client profile 里同时安装 plugin mode 和 skills-pack mode，除非你正在测试重复 discovery。
 
@@ -142,22 +137,22 @@ Anti-Spiral correction、Beta identity / namespace 与 diagnostic 坐标。Beta 
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-plugins-1.10.0.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.10.0/mindthus-plugins-1.10.0.tar.gz"
+  -o /tmp/mindthus-plugins-1.10.1.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.10.1/mindthus-plugins-1.10.1.tar.gz"
 rm -rf /tmp/mindthus-plugins
 mkdir -p /tmp/mindthus-plugins
-tar -xzf /tmp/mindthus-plugins-1.10.0.tar.gz -C /tmp/mindthus-plugins --strip-components=1
+tar -xzf /tmp/mindthus-plugins-1.10.1.tar.gz -C /tmp/mindthus-plugins --strip-components=1
 ```
 
 Skills 包，供 Codex skills-pack / Claude Code personal skills / OpenCode 使用：
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-skills-1.10.0.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.10.0/mindthus-skills-1.10.0.tar.gz"
+  -o /tmp/mindthus-skills-1.10.1.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.10.1/mindthus-skills-1.10.1.tar.gz"
 rm -rf /tmp/mindthus-skills
 mkdir -p /tmp/mindthus-skills
-tar -xzf /tmp/mindthus-skills-1.10.0.tar.gz -C /tmp/mindthus-skills --strip-components=1
+tar -xzf /tmp/mindthus-skills-1.10.1.tar.gz -C /tmp/mindthus-skills --strip-components=1
 ```
 
 ### Codex Plugin Mode（推荐）
@@ -181,7 +176,7 @@ codex plugin marketplace remove mindthus
 ### Codex ROI Beta（实验）
 
 只在高能力 Codex / GPT-Sol 上复查低开销唤起实验时使用。这个
-`v1.10.0-roi-beta` 包从精确 `v1.10.0` Stable shared core 组装，继承完整 SRA Skill、
+`v1.10.1-roi-beta` 包从精确 `v1.10.1` Stable shared core 组装，继承完整 SRA Skill 与本版 TPlan authority-integrity 修复、
 v0.3/v0.4 输入兼容、比例化校准、checked Decision Card、rerank lineage、Root-Cause Replacement、
 competitive-frame convergence、WAE Ownership Closure、Judgment Trace、Case Export、case-prep、
 Test Lifecycle 与现有 TPlan 能力；运行时差异限定为 SRA-compatible ROI Thin Core、历史 ROI.2
@@ -190,11 +185,11 @@ Stable 与 ROI Beta 可以独立安装或移除：
 
 ```bash
 curl -L \
-  -o /tmp/mindthus-beta-1.10.0-roi-beta.tar.gz \
-  "https://github.com/rv198-star/Mindthus/releases/download/v1.10.0/mindthus-beta-1.10.0-roi-beta.tar.gz"
+  -o /tmp/mindthus-beta-1.10.1-roi-beta.tar.gz \
+  "https://github.com/rv198-star/Mindthus/releases/download/v1.10.1/mindthus-beta-1.10.1-roi-beta.tar.gz"
 rm -rf /tmp/mindthus-roi-beta
 mkdir -p /tmp/mindthus-roi-beta
-tar -xzf /tmp/mindthus-beta-1.10.0-roi-beta.tar.gz -C /tmp/mindthus-roi-beta --strip-components=1
+tar -xzf /tmp/mindthus-beta-1.10.1-roi-beta.tar.gz -C /tmp/mindthus-roi-beta --strip-components=1
 codex plugin marketplace add /tmp/mindthus-roi-beta
 codex plugin add mindthus-beta@mindthus-beta
 ```
@@ -313,7 +308,7 @@ python3 scripts/log-fidelity-usage.py --help
 
 ## 版本与许可
 
-当前仓库版本：`v1.10.0`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
+当前仓库版本：`v1.10.1`。完整变化请看 [CHANGELOG.md](CHANGELOG.md) 和 [GitHub Releases](https://github.com/rv198-star/Mindthus/releases)。
 
 Mindthus uses AGPLv3 + commercial dual licensing.
 

--- a/docs/releases/v1.10.1-roi-beta.md
+++ b/docs/releases/v1.10.1-roi-beta.md
@@ -1,0 +1,31 @@
+# Mindthus v1.10.1 ROI Beta 发布说明
+
+发布日期：2026-09-05
+
+`v1.10.1-roi-beta` 是 `v1.10.1` GitHub Release 的 supplemental experimental asset，与 Stable 同步发布，不是独立 Stable release，也不取代 `v1.10.1 Stable`。
+
+## 组装边界
+
+- Shared Product Core 固定为精确 `v1.10.1` Stable release commit / tree，完整继承本 patch 的 TPlan Evidence Referential Integrity、Active Path Atomicity、Decision Consequence Integrity 与 Mission Completion Integrity 修复。
+- SRA Proportionate Allocation、v0.3/v0.4 输入兼容、completion criterion reference、checked Decision Card 与 rerank lineage 继续来自 Stable shared core。
+- Runtime delta 不新增能力，继续使用已资格验证的 **SRA-compatible ROI Thin Core**、历史 ROI.2 单句 3L5S Anti-Spiral correction、Beta identity / namespace 与 diagnostic 坐标。
+- Beta overlay 不复制 Stable 的 TPlan 修复，不新增第二套 evidence、completion、continuation 或 Mission mutation owner。
+
+## Patch 同步原则
+
+本版 Beta 的目标只是让实验入口运行在与 `v1.10.1` Stable 相同的已修复产品核心上。没有必要因为 Stable correctness patch 重新声称 Beta 的模型质量、自然唤醒率或 Token ROI 得到改善。
+
+## 证据上限
+
+本版 Beta 发布验证覆盖 deterministic composition、shared-core identity、namespace isolation、打包可复现性、runtime diagnostic 与已有 Beta overlay compatibility。
+
+没有重新测量 Beta-specific 自然唤醒率、相对模型胜率、真实任务收益或 Token ROI，因此不作新增效果声明。真实 Codex App / Sol High 长任务是否因本 patch 减少执行过载也尚未通过回放证明。
+
+## 发布形态
+
+- source tag：`v1.10.1-roi-beta`
+- GitHub Release：与 Stable 共用 `v1.10.1` Release
+- asset：`mindthus-beta-1.10.1-roi-beta.tar.gz`
+- checksum：收录于同一 Release 的 `SHA256SUMS`
+
+该归档继续使用独立 `mindthus-beta` Codex plugin / marketplace identity。需要完整 Stable 默认行为、通用 skills-pack 或保守部署时，应安装 Stable，而不是 ROI Beta。

--- a/docs/releases/v1.10.1.md
+++ b/docs/releases/v1.10.1.md
@@ -1,0 +1,90 @@
+# Mindthus v1.10.1 发布说明
+
+发布日期：2026-09-05
+
+发布 tag：`v1.10.1`
+
+## 版本定位
+
+`v1.10.1` 是 `v1.10.0` 的 **TPlan Authority Integrity Bugfix patch**。
+
+本版不新增方法、route、判断 owner 或 TPlan runtime generation。它来自一次真实的 Codex App / Sol High 长任务事故复盘：该任务执行约16小时仍未达到用户预期，随后对当前 `v1.10.0` TPlan 公共 API 的独立合成反例确认了四类确定性合同缺口。修复范围只关闭这些 correctness gaps，不把单次事故扩大解释成普遍性能结论。
+
+## 四项 TPlan 正确性修复
+
+### Evidence Referential Integrity
+
+新 lifecycle 记录中的 `refs.evidence_ids` 现在必须在同一 Mission 的锁定证据边界中唯一解析：
+
+- 可以引用已有唯一 evidence event；
+- 可以引用同一事务中原子新增的 prepared evidence event；
+- 缺失 ID、跨 Mission ID、歧义重复 ID、误填的文件路径在写入前失败；
+- `artifact_refs` 保持独立语义，脚本不会把错误 evidence ID 自动洗成 artifact。
+
+历史坏引用保持可读，不回写伪证据，也不会让无关合法写入永久失败。
+
+### Active Path Atomicity
+
+动态节点显式创建为 `active` 时，现在复用 canonical activation：节点状态、`active_task_id` 和 lifecycle consequence 在一个逻辑事务内保持一致。默认 `pending` 创建不抢游标；活动祖先、当前执行叶和 `requires_human` 的 blocked recovery cursor 继续保留既有合法语义。
+
+### Decision Consequence Integrity
+
+`continuation_authorization.authorized_action` 现在作为真正的执行 ceiling，而不是仅作枚举字段：
+
+- `stop`、`mission_review`、`anti_spiral_audit` 不能同时授权继续执行/激活类 mutation；
+- ordinary `apply_decision()` 与 Interaction Guard 授权应用共用同一 consequence validator；
+- weak/unclear ROI、lint 或证据增量等定性字段仍由 Agentic judgment 解释，不被机械转换成停止算法。
+
+### Mission Completion Integrity
+
+新的 Mission `completed` 事务必须同时满足：
+
+1. 所有 `role=success-critical` 节点均为 `completed`；
+2. 每个 Mission acceptance ID 的最新 mechanically qualified observation 为正。
+
+现有 `acceptance_passed`、`acceptance_failed` 和完整 legacy `acceptance` 合同被直接复用，没有新增第二套验收数据库或 schema。脚本只判断引用、范围和机械正反状态，不判断 PPT 视觉质量、reviewer 是否聪明或 synthetic test 是否等价于真实 Office holdout。
+
+## 实施后评审补充
+
+实施后自评审继续检查了 canonical writer coverage，并关闭两处旁路：
+
+- 既有 Mission 的兼容 `write_mission()` 更新重新进入 canonical transaction boundary，不能直接绕过新的完成/引用后果检查；
+- 独立 lifecycle trace append 对新的 evidence reference 也使用同一解析规则。
+
+`check_mission.py` 对历史坏引用和缺乏当前验收支持的 completed 状态给出明确诊断；它不修改历史，也不把旧状态自动认证为符合新合同。
+
+## 验证边界
+
+四项修复在合并前已完成 fresh-worktree 全套回归、Test Lifecycle、五布局 release pack / isolated import 与 GitHub CI。补丁发版阶段不再重开一轮资格验证，只执行版本面一致性、打包可复现性、tag/source 与发布资产校验。
+
+这些验证证明确定性合同和发行包在已覆盖范围内一致，不证明真实 Codex App / Sol High 下相似长任务执行过载已经不会再次发生。
+
+## ROI Beta 同步发布
+
+Mindthus 按 Stable release 默认规则同步提供 `v1.10.1-roi-beta` supplemental experimental asset。
+
+Beta 从精确 `v1.10.1` Stable shared core 组装，因此继承本版 TPlan authority-integrity 修复；Beta runtime delta 不新增能力，继续限定为已经资格验证的 SRA-compatible ROI Thin Core、历史 ROI.2 3L5S Anti-Spiral correction、独立 identity / namespace 与 diagnostic 坐标。
+
+本 patch 不新增 Beta-specific 自然唤醒率、相对模型胜率、真实任务收益或 Token ROI 声明。
+
+## 兼容性
+
+- `v1.10.1` 是 `v1.10.0` 的向后兼容 Bugfix patch。
+- SRA Proportionate Allocation、v0.3/v0.4 输入合同、completion criterion reference、Decision Card 和 rerank lineage 保持 `v1.10.0` 行为。
+- TPlan runtime generation 保持 `1.5.4` / `mindthus-v1.5.4`。
+- 开发与发版仍要求 CPython 3.10+；CI 使用 Python 3.11。
+
+## Claim ceiling 与后续
+
+本版不声称解决完整的16小时执行过载问题。跨工作区/跨 retry 的累计资源 tranche 与受管续投由 #200 继续设计；Codex App/CLI Hook 激活可靠性由 #146，宿主原生 mutation prevention 由 #140 继续负责。
+
+## 发布资产
+
+`v1.10.1` GitHub Release 提供：
+
+- `mindthus-plugins-1.10.1.tar.gz`
+- `mindthus-skills-1.10.1.tar.gz`
+- `mindthus-beta-1.10.1-roi-beta.tar.gz`
+- `SHA256SUMS`
+
+`SHA256SUMS` 覆盖三份归档。ROI Beta source tag 为 `v1.10.1-roi-beta`。

--- a/scripts/build-release-pack.py
+++ b/scripts/build-release-pack.py
@@ -9,7 +9,7 @@ import shutil
 from pathlib import Path
 
 
-VERSION = "1.10.0"
+VERSION = "1.10.1"
 EXCLUDED_DIRS = {
     "__pycache__",
     ".pytest_cache",

--- a/scripts/log-mindthus-runtime.py
+++ b/scripts/log-mindthus-runtime.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 
-VERSION = "1.10.0"
+VERSION = "1.10.1"
 PACKAGE_IDENTITY = "mindthus"
 MARKETPLACE_IDENTITY = "mindthus"
 RELATIVE_FILES = (

--- a/tests/test_log_mindthus_runtime.py
+++ b/tests/test_log_mindthus_runtime.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "log-mindthus-runtime.py"
-CURRENT_VERSION = "1.10.0"
+CURRENT_VERSION = "1.10.1"
 
 
 USING_TEXT = """\

--- a/tests/test_packaging_docs.py
+++ b/tests/test_packaging_docs.py
@@ -55,7 +55,7 @@ class PackagingDocsTests(unittest.TestCase):
             root = Path(tmp)
             out = root / "release"
             codex_home = root / "home"
-            cache = codex_home / "plugins" / "cache" / "mindthus" / "mindthus" / "1.10.0"
+            cache = codex_home / "plugins" / "cache" / "mindthus" / "mindthus" / "1.10.1"
             result = subprocess.run(
                 [sys.executable, str(script), "--package", "plugins", "--out", str(out)],
                 text=True,
@@ -642,7 +642,7 @@ class PackagingDocsTests(unittest.TestCase):
         for phrase in (
             "mindthus:tplan",
             "mindthus:*",
-            "当前仓库版本：`v1.10.0`",
+            "当前仓库版本：`v1.10.1`",
             "GitHub Releases",
             "局部正确",
             "输入定框审计",
@@ -1381,7 +1381,7 @@ class PackagingDocsTests(unittest.TestCase):
             source = marketplace["plugins"][0]["source"]
             self.assertEqual(source, "./claude-plugin")
             self.assertNotIn("..", source)
-            self.assertEqual(plugin["version"], "1.10.0")
+            self.assertEqual(plugin["version"], "1.10.1")
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "tplan" / "SKILL.md").exists())
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "mpg" / "SKILL.md").exists())
             self.assertTrue((out / "claude-code" / "claude-plugin" / "skills" / "sra" / "SKILL.md").exists())
@@ -1480,7 +1480,7 @@ class PackagingDocsTests(unittest.TestCase):
             )
             self.assertEqual(codex_marketplace["plugins"][0]["policy"]["installation"], "AVAILABLE")
             self.assertEqual(codex_plugin_manifest["name"], "mindthus")
-            self.assertEqual(codex_plugin_manifest["version"], "1.10.0")
+            self.assertEqual(codex_plugin_manifest["version"], "1.10.1")
             self.assertEqual(codex_plugin_manifest["skills"], "./skills/")
             self.assertEqual(codex_plugin_manifest["license"], "AGPL-3.0-only")
             self.assertEqual(codex_plugin_manifest["interface"]["brandColor"], "#161614")
@@ -1604,8 +1604,8 @@ class PackagingDocsTests(unittest.TestCase):
         script = REPO / "scripts" / "build-release-pack.py"
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            plugins = tmp_dir / "mindthus-plugins-1.10.0"
-            skills = tmp_dir / "mindthus-skills-1.10.0"
+            plugins = tmp_dir / "mindthus-plugins-1.10.1"
+            skills = tmp_dir / "mindthus-skills-1.10.1"
 
             plugin_result = subprocess.run(
                 ["python3", str(script), "--package", "plugins", "--out", str(plugins)],

--- a/tests/test_release_boundary_contract.py
+++ b/tests/test_release_boundary_contract.py
@@ -36,12 +36,12 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         self.assertIn("rather than encoded in the SPDX field", readme)
 
     def test_current_release_log_does_not_record_exact_suite_count(self):
-        release_log = (REPO / "docs" / "releases" / "v1.10.0.md").read_text(
+        release_log = (REPO / "docs" / "releases" / "v1.10.1.md").read_text(
             encoding="utf-8"
         )
         self.assertIsNone(re.search(r"\b\d+\s+tests\s+OK\b", release_log))
 
-    def test_current_v1_10_0_release_preserves_prior_roi_beta_history(self):
+    def test_current_v1_10_1_release_preserves_prior_roi_beta_history(self):
         readme = (REPO / "README.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
         builder = (REPO / "scripts" / "build-release-pack.py").read_text(encoding="utf-8")
@@ -50,22 +50,24 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         release_log = (REPO / "docs" / "releases" / "v1.8.0.md").read_text(encoding="utf-8")
         beta_notes = (REPO / "docs" / "releases" / "v1.8.0-roi-beta.md").read_text(encoding="utf-8")
 
-        self.assertIn("当前仓库版本：`v1.10.0`", readme)
+        self.assertIn("当前仓库版本：`v1.10.1`", readme)
         self.assertEqual(readme.count("当前仓库版本："), 1)
-        self.assertIn("当前已发布 Stable 是 `v1.10.0`", readme)
-        self.assertIn("mindthus-plugins-1.10.0.tar.gz", readme)
-        self.assertIn("mindthus-skills-1.10.0.tar.gz", readme)
-        self.assertIn("mindthus-beta-1.10.0-roi-beta.tar.gz", readme)
+        self.assertIn("当前已发布 Stable 是 `v1.10.1`", readme)
+        self.assertIn("mindthus-plugins-1.10.1.tar.gz", readme)
+        self.assertIn("mindthus-skills-1.10.1.tar.gz", readme)
+        self.assertIn("mindthus-beta-1.10.1-roi-beta.tar.gz", readme)
         self.assertIn("Scarce Resource Allocation", readme)
+        self.assertIn("## v1.10.1", changelog)
         self.assertIn("## v1.10.0", changelog)
-        self.assertIn("补充发布包：1.10.0 ROI Beta", changelog)
+        self.assertIn("补充发布包：1.10.1 ROI Beta", changelog)
+        self.assertIn("v1.10.1-roi-beta", changelog)
         self.assertIn("v1.10.0-roi-beta", changelog)
         self.assertIn("## v1.9.1", changelog)
         self.assertIn("## v1.8.0", changelog)
         self.assertIn("补充发布包：1.9.1 ROI Beta", changelog)
         self.assertIn("v1.9.1-roi-beta", changelog)
-        self.assertIn('VERSION = "1.10.0"', builder)
-        self.assertIn('VERSION = "1.10.0"', runtime_logger)
+        self.assertIn('VERSION = "1.10.1"', builder)
+        self.assertIn('VERSION = "1.10.1"', runtime_logger)
         self.assertIn('"package_version": "1.5.4"', tplan_manifest)
         self.assertIn('"source_id": "mindthus-v1.5.4"', tplan_manifest)
         for phrase in (
@@ -88,8 +90,8 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
 
     def test_release_defaults_publish_roi_beta_unless_explicitly_exempted(self):
         policy = (REPO / "docs" / "internal" / "release-defaults.md").read_text(encoding="utf-8")
-        release = (REPO / "docs" / "releases" / "v1.10.0.md").read_text(encoding="utf-8")
-        beta = (REPO / "docs" / "releases" / "v1.10.0-roi-beta.md").read_text(encoding="utf-8")
+        release = (REPO / "docs" / "releases" / "v1.10.1.md").read_text(encoding="utf-8")
+        beta = (REPO / "docs" / "releases" / "v1.10.1-roi-beta.md").read_text(encoding="utf-8")
         prior_beta = (REPO / "docs" / "releases" / "v1.9.1-roi-beta.md").read_text(encoding="utf-8")
         changelog = (REPO / "CHANGELOG.md").read_text(encoding="utf-8")
         for phrase in (
@@ -99,14 +101,14 @@ class ReleaseBoundaryContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, policy)
         self.assertIn("ROI Beta 同步发布", release)
-        self.assertIn("mindthus-plugins-1.10.0.tar.gz", release)
-        self.assertIn("mindthus-skills-1.10.0.tar.gz", release)
-        self.assertIn("mindthus-beta-1.10.0-roi-beta.tar.gz", release)
-        self.assertIn("v1.10.0-roi-beta", beta)
+        self.assertIn("mindthus-plugins-1.10.1.tar.gz", release)
+        self.assertIn("mindthus-skills-1.10.1.tar.gz", release)
+        self.assertIn("mindthus-beta-1.10.1-roi-beta.tar.gz", release)
+        self.assertIn("v1.10.1-roi-beta", beta)
         self.assertIn("SRA-compatible ROI Thin Core", beta)
         self.assertIn("Beta-specific", beta)
         self.assertIn("v1.9.1-roi-beta", prior_beta)
-        self.assertIn("补充发布包：1.10.0 ROI Beta", changelog)
+        self.assertIn("补充发布包：1.10.1 ROI Beta", changelog)
         self.assertIn("覆盖三份归档的 `SHA256SUMS`", changelog)
 
     def test_v1_4_6_release_surface_is_preserved(self):

--- a/tests/test_v1_0_1_usage_log.py
+++ b/tests/test_v1_0_1_usage_log.py
@@ -274,7 +274,7 @@ class V101UsageLogTests(unittest.TestCase):
         )
 
         for phrase in (
-            "当前仓库版本：`v1.10.0`",
+            "当前仓库版本：`v1.10.1`",
             "scripts/log-fidelity-usage.py",
             "data/fidelity-usage-log.jsonl",
             "可选：记录使用效果",
@@ -304,7 +304,7 @@ class V101UsageLogTests(unittest.TestCase):
                     / "plugin.json"
                 ).read_text(encoding="utf-8")
             )
-            self.assertEqual(plugin["version"], "1.10.0")
+            self.assertEqual(plugin["version"], "1.10.1")
             for platform_root in (
                 root / "claude-code" / "claude-plugin",
                 root / "codex",


### PR DESCRIPTION
Patch release preparation only. Publishes the merged #196-#199 TPlan authority-integrity bug fixes as v1.10.1, updates version surfaces and synchronized ROI Beta release notes. No runtime behavior changes beyond already-merged PR #204. Release-specific tests, lifecycle registry, diff check and all-layout release-pack build passed locally.