### PR TITLE
docs(release): verify v1.10.1 publication

### DIFF
--- a/docs/internal/audits/2026-09-05-v1.10.1-release-verification.md
+++ b/docs/internal/audits/2026-09-05-v1.10.1-release-verification.md
@@ -1,0 +1,131 @@
+# Mindthus v1.10.1 Release Verification
+
+Date: 2026-09-05
+
+Status: **PASS — publication verified**
+
+This is post-publication evidence. It is intentionally committed after the frozen Stable
+and ROI Beta source tags and does not move either tag.
+
+## Release scope
+
+`v1.10.1` is a compatibility bugfix patch over `v1.10.0`. The product change is limited
+to the already-reviewed TPlan authority-integrity fixes from #196–#199:
+
+- evidence-reference resolution for new lifecycle writes;
+- atomic create-and-activate state/cursor consequences;
+- continuation authorization consequence ceilings;
+- Mission completion prerequisites tied to success-critical work and qualified acceptance.
+
+The release does not implement #200 cross-root resource tranches, new host hooks, a new
+scheduler, new Mindthus methods, or a new TPlan runtime generation.
+
+## Stable source identity
+
+- source tag: `v1.10.1`
+- annotated tag object: `5bba580074a893913bb26c30cdcd892468cb6f2a`
+- peeled release commit: `6a1ef3ce02eeb88997b512f9d5ee1e7d26d08729`
+- release tree: `2532b0fe6e21b3ef979b31a62b2d23dbcceaebc3`
+- authority-integrity implementation merge: `ded07abc06585426dd2eb65d12a0b05805622141` / PR #204
+- release-prep merge: `6a1ef3ce02eeb88997b512f9d5ee1e7d26d08729` / PR #205
+
+PR #204 had fresh-worktree full-suite, lifecycle, release-pack and implementation-review
+evidence before merge. PR #205 changed only release/version surfaces and its GitHub
+`unittest-smoke` check completed successfully before the Stable tag was created.
+
+Per the explicit patch-release decision, no second product qualification campaign was
+run after those gates. Release-stage work was limited to version-surface consistency,
+reproducible packaging and publication verification.
+
+## Stable packaging
+
+Stable plugins and skills were each built twice independently from the exact Stable
+source. The corresponding archives were byte-identical between the two builds.
+
+The archive procedure was calibrated against the published `v1.10.0` plugins asset: a
+fresh build from `v1.10.0` reproduced its published SHA-256 byte-for-byte before the
+same procedure was used for `v1.10.1`.
+
+Final Stable archive SHA-256:
+
+- `mindthus-plugins-1.10.1.tar.gz`:
+  `785cb9e84cfb00e6ca8967bb9363f5736aad01eae28b17b8bd4abdc26ba992d9`
+- `mindthus-skills-1.10.1.tar.gz`:
+  `4d0d81bffdc31c2a225335a65cb4710b2393257a50abea1be92c4b65154c9ed6`
+
+The Stable Codex plugin manifest reports `mindthus` / `1.10.1`.
+
+## ROI Beta source identity
+
+- source tag: `v1.10.1-roi-beta`
+- annotated tag object: `1e371fc07fb9364f6b6587fba483572a8d6d6bca`
+- peeled Beta source commit: `890293e4b64d660993176f6b539f1d926294794e`
+- Beta source tree: `063406ee297c82db2f0e0b081fcb1aa9bd8d4d24`
+- exact Stable shared core: `6a1ef3ce02eeb88997b512f9d5ee1e7d26d08729`
+- Stable shared-core tree: `2532b0fe6e21b3ef979b31a62b2d23dbcceaebc3`
+- inherited ROI compatibility qualification: `bba86f751c4c80b0117787969e5ff5fcb695f3bb`
+- frozen ROI Thin Core implementation: `0bd58701fd36f33d5640ff2d00aa5e208026dbfa`
+
+The Beta source descends from `v1.10.0-roi-beta` and merges the exact `v1.10.1` Stable
+source. The patch adds no Beta-specific runtime delta, so the previously qualified SRA
+Thin Core is inherited rather than re-qualified as if model behavior had changed.
+
+Beta composition/build checks verified:
+
+- exact Stable shared-core commit/tree binding;
+- `mindthus-beta` identity/version `1.10.1-roi-beta`;
+- the four TPlan authority-integrity repair markers are present in the packaged shared core;
+- packaged profile `assembly_source_ref` equals
+  `890293e4b64d660993176f6b539f1d926294794e`;
+- package source tag is `v1.10.1-roi-beta`;
+- packaged Python compiled successfully;
+- two independent Beta builds produced byte-identical archives.
+
+Final ROI Beta archive SHA-256:
+
+- `mindthus-beta-1.10.1-roi-beta.tar.gz`:
+  `3cf8a3e7fa8f4799aad85a092d6827ea95156fc1b25325a5fd8b30898c5119ff`
+
+## GitHub Release publication
+
+GitHub Release:
+
+- tag: `v1.10.1`
+- title: `Mindthus v1.10.1`
+- published: `2026-09-05T15:40:12Z`
+- draft: false
+- prerelease: false
+- Latest: yes
+
+Published assets:
+
+| Asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `mindthus-plugins-1.10.1.tar.gz` | 1,349,689 | `785cb9e84cfb00e6ca8967bb9363f5736aad01eae28b17b8bd4abdc26ba992d9` |
+| `mindthus-skills-1.10.1.tar.gz` | 2,031,549 | `4d0d81bffdc31c2a225335a65cb4710b2393257a50abea1be92c4b65154c9ed6` |
+| `mindthus-beta-1.10.1-roi-beta.tar.gz` | 669,910 | `3cf8a3e7fa8f4799aad85a092d6827ea95156fc1b25325a5fd8b30898c5119ff` |
+| `SHA256SUMS` | 296 | `91e87a664b4fc8facbc0396808640460a4eb65208dd128a248216ee3d05d0710` |
+
+All four assets were downloaded again from the published Release into a fresh directory.
+`sha256sum -c SHA256SUMS` passed for all three archives. Every downloaded file was
+byte-identical to its frozen pre-upload artifact.
+
+Remote tag inspection confirmed both annotated tags and their peeled commits. The
+published Beta profile confirmed the exact Stable ref/tree and exact Beta assembly
+source listed above.
+
+## Claim ceiling
+
+This verification proves the named source identities, deterministic release packaging,
+Beta composition inheritance, asset reproducibility, publication state and downloaded
+checksums.
+
+It does not prove that the original approximately 16-hour Codex App / Sol High execution
+overrun cannot recur. It also does not prove Beta-specific natural activation, relative
+model quality, cross-host parity, Token ROI, or the value of future #200 resource-tranche
+controls. Those remain separate real-use and platform evidence questions.
+
+## Verdict
+
+`v1.10.1 Stable` and synchronized `v1.10.1-roi-beta` are published and verified. No
+release blocker remains in the publication contract covered by this record.


### PR DESCRIPTION
Post-publication verification only. Records immutable Stable/Beta source identities, reproducible archive hashes, GitHub Release assets, fresh download SHA256 verification, and claim ceiling. Does not move release tags or change product behavior.